### PR TITLE
add pycrypto dependency to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,14 +9,16 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-   
+
     name='pyrainbird',
     version='0.1.3',
     description='Rain Bird Controller',
     long_description=long_description,
 
+    install_requires=['pycrypto'],
+
     packages=find_packages(exclude=('tests', 'docs')),
-    
+
     #The project's main homepage.
     url='https://github.com/jbarrancos/pyrainbird/',
 


### PR DESCRIPTION
I was getting an error that pycrypto wasn't installed on my system when I went to use the Home Assistant RainBird integration.

This should fix the problem.

If/when this is merged and a new version released I can make the PR on Home Assistant's repo updating to the new version if you want.