### PR TITLE
simplifying interpretation of zone currently irrigating

### DIFF
--- a/pyrainbird/__init__.py
+++ b/pyrainbird/__init__.py
@@ -1,5 +1,4 @@
 import json
-import math
 import http.client
 import time
 import logging
@@ -94,12 +93,9 @@ class RainbirdController:
             if (resp != ""):
                 jsonresult=json.loads(resp)
                 if (jsonresult["result"]["data"][:2] == "BF"):
-                    val=jsonresult["result"]["data"][4:8]
-                    if (int(val[:2]) != 0):
-                      self.logger.debug("Status request acknowledged")
-                      return round(math.log(int(val[:2]),2)+1)
-                    else:
-                      return 0
+                    self.logger.debug("Status request acknowledged")
+                    val=jsonresult["result"]["data"][4:6]
+                    return int(val, 16).bit_length()
                 else:
                    self.logger.warning("Status request NOT acknowledged")
                    return -1


### PR DESCRIPTION
It's a 16 bit hex value bitmask for the zones.
This simplifies the algorithm and resolves #5 which pointed out that the higher level values were misinterpreted

My simple test program:
```
import pyrainbird
controller = pyrainbird.RainbirdController()
controller.setConfig("XXX.XXX.XXX.XXX","XXX")
for i in range(0,9):
    if i == 0:
        controller.stopIrrigation()
    else:
        controller.startIrrigation(i, 1)
    reported_zone = controller.currentIrrigation()
    print("Started -> Reported [ %s -> %s]" % (i, reported_zone))
```

which now outputs the same values as the commands: 
```
$ python ../test.py 
Started -> Reported [ 0 -> 0]
Started -> Reported [ 1 -> 1]
Started -> Reported [ 2 -> 2]
Started -> Reported [ 3 -> 3]
Started -> Reported [ 4 -> 4]
Started -> Reported [ 5 -> 5]
Started -> Reported [ 6 -> 6]
Started -> Reported [ 7 -> 7]
Started -> Reported [ 8 -> 8]
```

Whereas before it reported the values listed in #5. 

This is tested on a ST8-WiFi. It only goes as high as 8 zones so I don't think that the question about the 9th channel is valid.

While testing this I also verified that the commanded values agree with the LCD screen as well.
