### PR TITLE
Fixes zone 5 coming back as zone 4 on 'currentIrrigation' requests

### DIFF
--- a/pyrainbird/__init__.py
+++ b/pyrainbird/__init__.py
@@ -97,7 +97,7 @@ class RainbirdController:
                     val=jsonresult["result"]["data"][4:8]
                     if (int(val[:2]) != 0):
                       self.logger.debug("Status request acknowledged")
-                      return round(math.log(int(val[:2]),2)+1)
+                      return round(math.log(int("0x" + val[:2], 0),2)+1)
                     else:
                       return 0
                 else:


### PR DESCRIPTION
Zone 5 on my controller was reported as Zone 4, because the two characters in the response weren't being converted from hex.

This PR fixes that.