### PR TITLE
Do not install tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     classifiers=[],
     zip_safe=True,
     cmdclass={"test": PyTest},
-    packages=find_packages(),
+    packages=find_packages(exclude=("test", "test.*")),
     package_data={'': ['sipcommands.json']},
     include_package_data=True,
 )


### PR DESCRIPTION
Installing tests is generally not necessary or desirable in the first place, but particularly not in the global top level `test` package.

`test.*` is to catch possible subpackages added in the future.