### PR TITLE
Update __init__.py

### DIFF
--- a/pyrainbird/resources/__init__.py
+++ b/pyrainbird/resources/__init__.py
@@ -3,5 +3,7 @@ import json
 from pkg_resources import resource_string
 
 # parameters in number of nibbles (based on string representations of SIP bytes), total lengths in number of SIP bytes
-RAIBIRD_COMMANDS = json.loads(resource_string('pyrainbird.resources', 'sipcommands.json').decode("UTF-8"),
-                              encoding="UTF-8")
+
+# Changed in json version 3.9: The keyword argument encoding has been removed.
+# https://docs.python.org/3/library/json.html
+RAIBIRD_COMMANDS = json.loads(resource_string('pyrainbird.resources', 'sipcommands.json').decode("UTF-8"))


### PR DESCRIPTION
Changed in json version 3.9: The keyword argument encoding has been removed. (loads)
https://docs.python.org/3/library/json.html