### PR TITLE
Create github action to run tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Python application
 
 on:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r test_requirements.txt
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,6 +27,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r test_requirements.txt
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -14,7 +14,7 @@ class Pageable(object):
         return isinstance(o, Pageable) and self.page == o.page
 
     def __ne__(self, o):
-        return not __eq__(o)
+        return not self.__eq__(o)
 
     def __str__(self):
         return "page: %d" % self.page
@@ -31,7 +31,7 @@ class Echo(object):
         return isinstance(o, Echo) and self.echo == o.echo
 
     def __ne__(self, o):
-        return not __eq__(o)
+        return not self.__eq__(o)
 
     def __str__(self):
         return "echo: %02X" % self.echo
@@ -50,7 +50,7 @@ class CommandSupport(Echo):
         )
 
     def __ne__(self, o):
-        return not __eq__(o)
+        return not self.__eq__(o)
 
     def __hash__(self):
         return hash((super(CommandSupport, self).__hash__(), self.support))
@@ -82,7 +82,7 @@ class ModelAndVersion(object):
         )
 
     def __ne__(self, o):
-        return not __eq__(o)
+        return not self.__eq__(o)
 
     def __str__(self):
         return "model: %04X, version: %d.%d" % (
@@ -119,7 +119,7 @@ class States(object):
         )
 
     def __ne__(self, o):
-        return not __eq__(o)
+        return not self.__eq__(o)
 
     def __str__(self):
         result = ()
@@ -144,7 +144,7 @@ class AvailableStations(Pageable):
         )
 
     def __ne__(self, o):
-        return not __eq__(o)
+        return not self.__eq__(o)
 
     def __str__(self):
         return "available stations: %X, %s" % (
@@ -169,7 +169,7 @@ class WaterBudget(object):
         )
 
     def __ne__(self, o):
-        return not __eq__(o)
+        return not self.__eq__(o)
 
     def __str__(self):
         return "water budget: program: %d, hi: %02X, lo: %02X" % (

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -1,4 +1,4 @@
-from resources import RAINBIRD_MODELS
+from .resources import RAINBIRD_MODELS
 
 _DEFAULT_PAGE = 0
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --cov=pyrainbird --cov-report=term-missing --pep8 --flakes --mccabe
+addopts = --cov=pyrainbird --cov-report=term-missing
 testpaths = test

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,11 +3,8 @@ parameterized
 mccabe
 pyflakes
 pytest-cov
-pytest-flakes<4
-pytest-mccabe<2
-pytest-pep8
 pytest-mock
-pytest<6
+pytest
 six
 requests
 setuptools

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,11 +3,11 @@ parameterized
 mccabe
 pyflakes
 pytest-cov
-pytest-flakes
-pytest-mccabe
+pytest-flakes<4
+pytest-mccabe<2
 pytest-pep8
 pytest-mock
-pytest
+pytest<6
 six
 requests
 setuptools

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 responses
 parameterized
-mccabe
 pyflakes
 pytest-cov
 pytest-mock
@@ -8,3 +7,4 @@ pytest
 six
 requests
 setuptools
+flake8


### PR DESCRIPTION
Add a github action that runs tests when submitted. Right now, the tests don't appear to pass using standard ways to run tests, so sending this PR to show the failure, then will also submit additional fixes so they pass.

The motivation is to setup a baseline of a working repository before sending additional improvements.

The fixes required include:
- Tests won't run with latest versions of pytest, flakes mccabe, etc.  These have been replaced with flake8 which is the default suggested by new github actions
- Relative import is missing .
- Fix flake8 lint errors

See https://github.com/allenporter/pyrainbird/pull/1/checks for the results of the checks

