### PR TITLE
Improve test coverage for rainbird client

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,5 @@ pytest-mock==3.10.0
 pytest==7.2.0
 six==1.16.0
 requests==2.22.0
+requests-mock==1.10.0
 flake8==5.0.4

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch
+import requests_mock
+import requests
+import json
+
+from pyrainbird import RainbirdClient
+from pyrainbird import encryption
+
+HOST = "host"
+URL = "http://host/stick"
+PASSWORD = "password"
+REQUEST = "example data"
+LENGTH = len(REQUEST)
+
+RESULT_DATA = "result-data"
+RESPONSE = json.dumps({
+    "result": {
+        "data": RESULT_DATA,
+    }
+})
+RESPONSE = encryption.encrypt(RESPONSE, PASSWORD)
+
+
+def test_request() -> None:
+    """Test a basic request."""
+
+    client = RainbirdClient(HOST, PASSWORD, retry=1, retry_sleep=0)
+
+    with requests_mock.mock() as m:
+        m.post(URL, content=RESPONSE)
+
+        resp = client.request(REQUEST, LENGTH)
+
+    assert resp == RESULT_DATA
+
+
+def test_request_failure() -> None:
+    """Test a basic request failure handling."""
+
+    client = RainbirdClient(HOST, PASSWORD, retry=2, retry_sleep=0)
+
+    with requests_mock.mock() as m:
+        m.post(URL, status_code=500)
+        resp = client.request(REQUEST, LENGTH)
+
+    assert resp is None
+
+
+def test_request_timeout() -> None:
+    """Test a timeout while connecting."""
+
+    client = RainbirdClient(HOST, PASSWORD, retry=2, retry_sleep=0)
+
+    with requests_mock.mock() as m:
+        m.post(URL, exc=requests.exceptions.ConnectTimeout)
+        resp = client.request(REQUEST, LENGTH)
+
+    assert resp is None
+
+
+def test_request_failure_retry() -> None:
+    """Test a failure retry behavior"""
+
+    client = RainbirdClient(HOST, PASSWORD, retry=2, retry_sleep=0)
+
+    with requests_mock.mock() as m:
+        m.register_uri('POST', URL, [
+            {'status_code': 500},
+            {'content': RESPONSE, 'status_code': 200}
+        ])
+        resp = client.request(REQUEST, LENGTH)
+
+    assert resp == RESULT_DATA


### PR DESCRIPTION
Improve test coverage for rainbird client in preparation for future changes. `client.py` now has 100% coverage.

Issue #20