### PR TITLE
Add an asyncio rainbird client

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -1,0 +1,205 @@
+"""Client library for rainbird.
+
+This is an asyncio based client library for rainbird.
+"""
+
+import datetime
+import logging
+
+import aiohttp
+from aiohttp.client_exceptions import ClientError
+
+from . import encryption, rainbird
+from .data import _DEFAULT_PAGE, AvailableStations, ModelAndVersion, States, WaterBudget
+from .resources import RAINBIRD_COMMANDS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RainbirdApiException(Exception):
+    """Exception from rainbird api."""
+
+
+class AsyncRainbirdClient:
+    """An asyncio rainbird client."""
+
+    def __init__(
+        self, websession: aiohttp.ClientSession, host: str, password: str
+    ) -> None:
+        self._websession = websession
+        self._url = host if host.startswith("/") else f"http://{host}/stick"
+        self._coder = encryption.PayloadCoder(password, _LOGGER)
+
+    async def request(self, data: str, length: int) -> str:
+        payload = self._coder.encode_request(data, length)
+        try:
+            resp = await self._websession.request("post", self._url, data=payload)
+            resp.raise_for_status()
+        except ClientError as err:
+            raise RainbirdApiException(f"Error from API: {str(err)}") from err
+        content = await resp.read()
+        return self._coder.decode_response(content)
+
+
+class AsyncRainbirdController:
+    """Rainbord controller that uses asyncio."""
+
+    def __init__(self, client: AsyncRainbirdClient):
+        """Initialize AsyncRainbirdController."""
+        self._client = client
+
+    async def get_model_and_version(self) -> ModelAndVersion:
+        """Return the model and version."""
+        return await self._process_command(
+            lambda response: ModelAndVersion(
+                response["modelID"],
+                response["protocolRevisionMajor"],
+                response["protocolRevisionMinor"],
+            ),
+            "ModelAndVersion",
+        )
+
+    async def get_available_stations(self, page=_DEFAULT_PAGE) -> AvailableStations:
+        """Get the available stations."""
+        mask = (
+            "%%0%dX"
+            % RAINBIRD_COMMANDS["ControllerResponses"]["83"]["setStations"]["length"]
+        )
+        return await self._process_command(
+            lambda resp: AvailableStations(
+                mask % resp["setStations"], page=resp["pageNumber"]
+            ),
+            "AvailableStations",
+            page,
+        )
+
+    async def get_serial_number(self) -> str:
+        """Get the device serial number."""
+        return await self._process_command(
+            lambda resp: resp["serialNumber"], "SerialNumber"
+        )
+
+    async def get_current_time(self) -> datetime.time:
+        """Get the device current time."""
+        return await self._process_command(
+            lambda resp: datetime.time(resp["hour"], resp["minute"], resp["second"]),
+            "CurrentTime",
+        )
+
+    async def get_current_date(self) -> datetime.date:
+        """Get the device current date."""
+        return await self._process_command(
+            lambda resp: datetime.date(resp["year"], resp["month"], resp["day"]),
+            "CurrentDate",
+        )
+
+    async def water_budget(self, budget) -> WaterBudget:
+        """Return the water budget."""
+        return await self._process_command(
+            lambda resp: WaterBudget(resp["programCode"], resp["seasonalAdjust"]),
+            "WaterBudget",
+            budget,
+        )
+
+    async def get_rain_sensor_state(self) -> bool | None:
+        """Get the current state for the rain sensor."""
+        return await self._process_command(
+            lambda resp: bool(resp["sensorState"]),
+            "CurrentRainSensorState",
+        )
+
+    async def get_zone_states(self, page=_DEFAULT_PAGE) -> States:
+        """Return the current state of the zone."""
+        mask = (
+            "%%0%dX"
+            % RAINBIRD_COMMANDS["ControllerResponses"]["BF"]["activeStations"]["length"]
+        )
+        return await self._process_command(
+            lambda resp: States((mask % resp["activeStations"])[:4]),
+            "CurrentStationsActive",
+            page,
+        )
+
+    async def get_zone_state(self, zone: int) -> bool:
+        """Return the current state of the zone."""
+        states = await self.get_zone_states()
+        return states.active(zone)
+
+    async def set_program(self, program: int) -> None:
+        """Start a program."""
+        await self._process_command(lambda resp: True, "ManuallyRunProgram", program)
+
+    async def test_zone(self, zone: int) -> None:
+        """Test a zone."""
+        await self._process_command(lambda resp: True, "TestStations", zone)
+
+    async def irrigate_zone(self, zone: int, minutes: int) -> None:
+        """Send the irrigate command."""
+        await self._process_command(
+            lambda resp: True, "ManuallyRunStation", zone, minutes
+        )
+
+    async def stop_irrigation(self) -> None:
+        """Send the stop command."""
+        await self._process_command(lambda resp: True, "StopIrrigation")
+
+    async def get_rain_delay(self) -> int:
+        """Return the current rain delay value."""
+        return await self._process_command(
+            lambda resp: resp["delaySetting"], "RainDelayGet"
+        )
+
+    async def set_rain_delay(self, days: int) -> None:
+        """Set the rain delay value in days."""
+        await self._process_command(lambda resp: True, "RainDelaySet", days)
+
+    async def advance_zone(self, param: int) -> None:
+        """Advance to the zone with the specified param."""
+        await self._process_command(lambda resp: True, "AdvanceStation", param)
+
+    async def get_current_irrigation(self) -> bool:
+        """Return True if the irrigation state is on."""
+        return await self._process_command(
+            lambda resp: bool(resp["irrigationState"]),
+            "CurrentIrrigationState",
+        )
+
+    async def _command(self, command: str, *args) -> str:
+        data = rainbird.encode(command, *args)
+        _LOGGER.debug("Request to line: " + str(data))
+        decrypted_data = await self._client.request(
+            data,
+            RAINBIRD_COMMANDS["ControllerCommands"]["%sRequest" % command]["length"],
+        )
+        _LOGGER.debug("Response from line: " + str(decrypted_data))
+        decoded = rainbird.decode(decrypted_data)
+        if (
+            decrypted_data[:2]
+            != RAINBIRD_COMMANDS["ControllerCommands"]["%sRequest" % command][
+                "response"
+            ]
+        ):
+            raise RainbirdApiException(
+                "Status request failed with wrong response! Requested %s but got %s:\n%s"
+                % (
+                    RAINBIRD_COMMANDS["ControllerCommands"]["%sRequest" % command][
+                        "response"
+                    ],
+                    decrypted_data[:2],
+                    decoded,
+                )
+            )
+        _LOGGER.debug("Response: %s" % decoded)
+        return decoded
+
+    async def _process_command(self, funct, cmd, *args) -> str:
+        response = await self._command(cmd, *args)
+        return (
+            funct(response)
+            if response is not None
+            and response["type"]
+            == RAINBIRD_COMMANDS["ControllerResponses"][
+                RAINBIRD_COMMANDS["ControllerCommands"][cmd + "Request"]["response"]
+            ]["type"]
+            else response
+        )

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -101,7 +101,7 @@ class AsyncRainbirdController:
             budget,
         )
 
-    async def get_rain_sensor_state(self) -> bool | None:
+    async def get_rain_sensor_state(self) -> bool:
         """Get the current state for the rain sensor."""
         return await self._process_command(
             lambda resp: bool(resp["sensorState"]),

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 addopts = --cov=pyrainbird --cov-report=term-missing
 testpaths = test
+log_level = DEBUG
+asyncio_mode = auto

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,5 @@ requests-mock==1.10.0
 flake8==5.0.4
 pytest-aiohttp==1.0.4
 pytest-asyncio==0.20.3
+types-requests==2.28.11.5
+types-PyYAML==6.0.12.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 -e .
+aiohttp==3.8.3
 responses==0.22.0
 parameterized==0.8.1
 pyflakes==2.5.0
@@ -9,3 +10,5 @@ six==1.16.0
 requests==2.22.0
 requests-mock==1.10.0
 flake8==5.0.4
+pytest-aiohttp==1.0.4
+pytest-asyncio==0.20.3

--- a/test/async_client_test.py
+++ b/test/async_client_test.py
@@ -1,0 +1,249 @@
+"""Test for AsyncRainbirdController."""
+
+import datetime
+from collections.abc import Awaitable, Callable
+
+import aiohttp
+import pytest
+
+from pyrainbird import (
+    RAINBIRD_COMMANDS,
+    AvailableStations,
+    ModelAndVersion,
+    WaterBudget,
+)
+from pyrainbird.async_client import (
+    AsyncRainbirdClient,
+    AsyncRainbirdController,
+    RainbirdApiException,
+)
+from pyrainbird.encryption import encrypt
+
+from .conftest import LENGTH, PASSWORD, REQUEST, RESPONSE, RESULT_DATA, ResponseResult
+
+
+async def test_request(
+    rainbird_client: Callable[[], Awaitable[AsyncRainbirdClient]],
+    response: ResponseResult,
+) -> None:
+    """Test of basic request/response handling."""
+    response(aiohttp.web.Response(body=RESPONSE))
+    client = await rainbird_client()
+    resp = await client.request(REQUEST, LENGTH)
+    assert resp == RESULT_DATA
+
+
+async def test_request_failure(
+    rainbird_client: Callable[[], Awaitable[AsyncRainbirdClient]],
+    response: ResponseResult,
+) -> None:
+    """Test a basic request failure handling."""
+
+    response(aiohttp.web.Response(status=500))
+    client = await rainbird_client()
+    with pytest.raises(RainbirdApiException):
+        await client.request(REQUEST, LENGTH)
+
+
+@pytest.fixture(name="api_response")
+def mock_api_response(response: ResponseResult) -> Callable[[...], Awaitable[None]]:
+    """Fixture to construct a fake API response."""
+
+    def _put_result(command: str, **kvargs) -> None:
+        resp = RAINBIRD_COMMANDS["ControllerResponses"][command]
+        data = command + ("00" * (resp["length"] - 1))
+        for k in resp:
+            if k in ["type", "length"]:
+                continue
+            param_template = "%%0%dX" % (resp[k]["length"])
+            start_ = resp[k]["position"]
+            end_ = start_ + resp[k]["length"]
+            data = "%s%s%s" % (
+                data[:start_],
+                (param_template % kvargs[k]),
+                data[end_:],
+            )
+
+        body = encrypt(
+            ('{"jsonrpc": "2.0", "result": {"data":"%s"}, "id": 1} ' % data),
+            PASSWORD,
+        )
+        response(aiohttp.web.Response(body=body))
+
+    return _put_result
+
+
+async def test_get_model_and_version(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("82", modelID=16, protocolRevisionMajor=1, protocolRevisionMinor=3)
+    assert await controller.get_model_and_version() == ModelAndVersion(16, 1, 3)
+
+
+async def test_get_available_stations(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("83", pageNumber=1, setStations=0x7F000000)
+    assert await controller.get_available_stations() == AvailableStations("7f000000", 1)
+
+
+async def test_get_serial_number(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("85", serialNumber=0x12635436566)
+    assert await controller.get_serial_number() == 0x12635436566
+
+
+async def test_get_current_time(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    time = datetime.time()
+    api_response("90", hour=time.hour, minute=time.minute, second=time.second)
+    assert await controller.get_current_time() == time
+
+
+async def test_get_current_date(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    date = datetime.date.today()
+    api_response("92", year=date.year, month=date.month, day=date.day)
+    assert await controller.get_current_date() == date
+
+
+async def test_get_water_budget(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("B0", programCode=1, seasonalAdjust=65)
+    assert await controller.water_budget(5) == WaterBudget(1, 65)
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [(1, True), (0, False)],
+)
+async def test_get_rain_sensor(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+    state: int,
+    expected: bool,
+) -> None:
+    controller = await rainbird_controller()
+    api_response("BE", sensorState=state)
+    assert await controller.get_rain_sensor_state() == expected
+
+
+async def test_get_zone_state(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    for i in range(1, 9):
+        for j in range(1, 9):
+            mask = (1 << (i - 1)) * 0x1000000
+            api_response("BF", pageNumber=0, activeStations=mask)
+            assert await controller.get_zone_state(j) == (i == j)
+
+
+async def test_set_program(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("01", commandEcho=5)
+    await controller.set_program(5)
+
+
+async def test_irrigate_zone(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("01", pageNumber=0, commandEcho=6)
+    api_response("BF", pageNumber=0, activeStations=0b10000000000000000000000000000)
+    await controller.irrigate_zone(5, 30)
+
+
+async def test_test_zone(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("01", commandEcho=6)
+    await controller.test_zone(6)
+
+
+async def test_stop_irrigation(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("01", pageNumber=0, commandEcho=6)
+    api_response("BF", pageNumber=0, activeStations=0b0)
+    await controller.stop_irrigation()
+
+
+async def test_get_rain_delay(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("B6", delaySetting=16)
+    await controller.get_rain_delay() == 16
+
+
+async def test_set_rain_delay(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("01", pageNumber=0, commandEcho=6)
+    await controller.set_rain_delay(3)
+
+
+async def test_advance_zone(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("01", commandEcho=3)
+    await controller.advance_zone(3)
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        (1, True),
+        (0, False),
+    ],
+)
+async def test_get_current_irrigation(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+    state: int,
+    expected: bool,
+) -> None:
+    controller = await rainbird_controller()
+    api_response("C8", irrigationState=state)
+    assert await controller.get_current_irrigation() == expected
+
+
+async def test_not_acknowledge_response(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    api_response: Callable[[...], Awaitable[None]],
+) -> None:
+    controller = await rainbird_controller()
+    api_response("00", commandEcho=17, NAKCode=28)
+    with pytest.raises(RainbirdApiException):
+        await controller.irrigate_zone(1, 30)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,104 @@
+"""Test fixtures for pyrainbird."""
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from typing import Generator, cast
+
+import aiohttp
+import pytest
+from aiohttp.test_utils import TestClient
+
+from pyrainbird import encryption
+from pyrainbird.async_client import AsyncRainbirdClient, AsyncRainbirdController
+
+ResponseResult = Callable[[aiohttp.web.Response], None]
+
+
+PASSWORD = "password"
+REQUEST = "example data"
+LENGTH = len(REQUEST)
+
+RESULT_DATA = "result-data"
+RESPONSE = json.dumps(
+    {
+        "result": {
+            "data": RESULT_DATA,
+        }
+    }
+)
+RESPONSE = encryption.encrypt(RESPONSE, PASSWORD)
+
+
+@pytest.fixture(name="event_loop")
+def create_event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    """Fixture for producing event loop."""
+    yield asyncio.get_event_loop()
+
+
+async def handler(request: aiohttp.web.Request) -> aiohttp.web.Response:
+    """Handles the request, inserting response prepared by tests."""
+    request.app["request"].append(dict(await request.post()))
+    return request.app["response"].pop(0)
+
+
+@pytest.fixture(name="app")
+def mock_app() -> aiohttp.web.Application:
+    """Fixture to create the fake web app."""
+    app = aiohttp.web.Application()
+    app["response"] = []
+    app["request"] = []
+    app.router.add_post("/stick", handler)
+    return app
+
+
+@pytest.fixture(name="test_client")
+def cli_cb(
+    event_loop: asyncio.AbstractEventLoop,
+    app: aiohttp.web.Application,
+    aiohttp_client: Callable[[aiohttp.web.Application], Awaitable[TestClient]],
+) -> Callable[[], Awaitable[TestClient]]:
+    """Creates a fake aiohttp client."""
+
+    async def func() -> TestClient:
+        return await aiohttp_client(app)
+
+    return func
+
+
+@pytest.fixture(name="rainbird_client")
+def mock_rainbird_client(
+    test_client: Callable[[], Awaitable[TestClient]]
+) -> Callable[[], Awaitable[AsyncRainbirdClient]]:
+    """Fixture to fake out the auth library."""
+
+    async def func() -> AsyncRainbirdClient:
+        client = await test_client()
+        return AsyncRainbirdClient(
+            cast(aiohttp.ClientSession, client), "/stick", PASSWORD
+        )
+
+    return func
+
+
+@pytest.fixture(name="rainbird_controller")
+def mock_rainbird_controller(
+    rainbird_client: Callable[[], Awaitable[AsyncRainbirdClient]],
+) -> Callable[[], Awaitable[AsyncRainbirdController]]:
+    """Fixture to fake out the auth library."""
+
+    async def func() -> AsyncRainbirdController:
+        client = await rainbird_client()
+        return AsyncRainbirdController(client)
+
+    return func
+
+
+@pytest.fixture(name="response")
+def mock_response(app: aiohttp.web.Application) -> ResponseResult:
+    """Fixture to construct a fake API response."""
+
+    def _put_result(response: aiohttp.web.Response) -> None:
+        app["response"].append(response)
+
+    return _put_result


### PR DESCRIPTION
Add an `AsyncRainbirdClient` and `AsyncRainbirdController`.

These client libraries support asyncio, and are a copy though some of the encoding logic is shared. The response parsing has been streamlined a bit, and the client is simpler (e.g. does not support retries, etc) pushing that to be a responsibility of the caller.

Add tests with 100% test coverage.

Issue #20