### PR TITLE
Add support for cloud commands to AsyncRainbirdController

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -6,7 +6,7 @@ This is an asyncio based client library for rainbird.
 import datetime
 import logging
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Optional
 
 import aiohttp
 from aiohttp.client_exceptions import ClientError
@@ -52,7 +52,7 @@ class AsyncRainbirdClient:
         self,
         websession: aiohttp.ClientSession,
         host: str,
-        password: str | None,
+        password: Optional[str],
     ) -> None:
         self._websession = websession
         if host.startswith("/") or host.startswith("http://"):

--- a/pyrainbird/client.py
+++ b/pyrainbird/client.py
@@ -31,7 +31,9 @@ class RainbirdClient:
         self.coder = encryption.PayloadCoder(password, logger)
 
     def request(self, data, length):
-        payload = self.coder.encode_request(data, length)
+        payload = self.coder.encode_command(
+            "tunnelSip", {"data": data, "length": length}
+        )
         for i in range(0, self.retry):
             try:
                 resp = requests.post(
@@ -51,7 +53,7 @@ class RainbirdClient:
                     "Response: %d, %s" % (resp.status_code, resp.reason)
                 )
             else:
-                return self.coder.decode_response(resp.content)
+                return self.coder.decode_command(resp.content)["data"]
 
             time.sleep(self.retry_sleep)
             continue

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -1,3 +1,9 @@
+"""Data model for rainbird client api."""
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
 from .resources import RAINBIRD_MODELS
 
 _DEFAULT_PAGE = 0
@@ -176,3 +182,106 @@ class WaterBudget(object):
             self.program,
             self.adjust,
         )
+
+
+class WifiSettings(BaseModel):
+    """Wifi and other settings."""
+
+    """The mac address for the device, also referred to as the stick id."""
+    mac_address: Optional[str] = Field(alias="macAddress")
+
+    local_ip_address: Optional[str] = Field(alias="localIpAddress")
+    local_netmask: Optional[str] = Field(alias="localNetmask")
+    local_gateway: Optional[str] = Field(alias="localGateway")
+    rssi: Optional[int]
+    wifi_ssid: Optional[str] = Field(alias="wifiSsid")
+    wifi_password: Optional[str] = Field(alias="wifiPassword")
+    wifi_security: Optional[str] = Field(alias="wifiSecurity")
+    ap_timeout_no_lan: Optional[int] = Field(alias="apTimeoutNoLan")
+    ap_timeout_idle: Optional[int] = Field(alias="apTimeoutIdle")
+    ap_security: Optional[str] = Field(alias="apSecurity")
+    sick_version: Optional[str] = Field(alias="stickVersion")
+
+
+class Settings(BaseModel):
+    """Settings from the cloud API."""
+
+    flow_rates: list[str] = Field(default_factory=list, alias="FlowRates")
+    flow_units: list[str] = Field(default_factory=list, alias="FlowUnits")
+    code: Optional[str]
+    country: Optional[str]
+    global_disable: bool = Field(alias="globalDisable")
+    num_programs: int = Field(alias="numPrograms")
+    program_opt_out_mask: str = Field(alias="programOptOutMask")
+    soil_types: list[int] = Field(default_factory=[], alias="soilTypes")
+
+
+class ScheduleAndSettings:
+    """Schedule and settings form the cloud API."""
+
+    def __init__(self, status: Optional[str], settings: Optional[Settings]) -> None:
+        self._status = status
+        self._settings = settings
+
+    @property
+    def status(self) -> str:
+        """Return device status."""
+        return self._status
+
+    @property
+    def settings(self) -> Optional[Settings]:
+        """Return device settings."""
+        return self._settings
+
+    @classmethod
+    def parse_obj(cls, data: dict[str, Any]):
+        """Parse a ScheduleAndSettings from an API response."""
+        status = data.get("status", None)
+        settings = Settings.parse_obj(data["settings"]) if "settings" in data else None
+        return ScheduleAndSettings(status, settings)
+
+
+class Controller(BaseModel):
+    """Settings for the controller."""
+
+    available_stations: list[int] = Field(
+        alias="availableStations", default_factory=list
+    )
+    custom_name: Optional[str] = Field(alias="customName")
+    custom_program_names: dict[str, str] = Field(
+        alias="customProgramNames", default_factory=dict
+    )
+    custom_station_names: dict[str, str] = Field(
+        alias="customStationNames", default_factory=dict
+    )
+
+
+class Forecast(BaseModel):
+    """Weather forecast data from the cloud API."""
+
+    date_time: Optional[int] = Field(alias="dateTime")
+    icon: Optional[str]
+    description: Optional[str]
+    high: Optional[int]
+    low: Optional[int]
+    chance_of_rain: Optional[int]
+    precip: Optional[float]
+
+
+class Weather(BaseModel):
+    """Weather settings from the cloud API."""
+
+    city: Optional[str]
+    forecast: list[Forecast] = Field(default_factory=list)
+    location: Optional[str]
+    time_zone_id: Optional[str] = Field(alias="timeZoneId")
+    time_zone_raw_offset: Optional[str] = Field(alias="timeZoneRawOffset")
+
+
+class WeatherAndStatus(BaseModel):
+    """Weather and status from the cloud API."""
+
+    stick_id: Optional[str] = Field(alias="StickId")
+    controller: Optional[Controller] = Field(alias="Controller")
+    forecasted_rain: Optional[dict[str, Any]] = Field(alias="ForecastedRain")
+    weather: Optional[Weather] = Field(alias="Weather")

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -184,11 +184,11 @@ class WaterBudget(object):
         )
 
 
-class WifiSettings(BaseModel):
-    """Wifi and other settings."""
+class WifiParams(BaseModel):
+    """Wifi parameters for the device."""
 
-    """The mac address for the device, also referred to as the stick id."""
     mac_address: Optional[str] = Field(alias="macAddress")
+    """The mac address for the device, also referred to as the stick id."""
 
     local_ip_address: Optional[str] = Field(alias="localIpAddress")
     local_netmask: Optional[str] = Field(alias="localNetmask")
@@ -203,17 +203,32 @@ class WifiSettings(BaseModel):
     sick_version: Optional[str] = Field(alias="stickVersion")
 
 
-class Settings(BaseModel):
-    """Settings from the cloud API."""
+class ProgramInfo(BaseModel):
+    """Program information for the device."""
 
-    flow_rates: list[str] = Field(default_factory=list, alias="FlowRates")
-    flow_units: list[str] = Field(default_factory=list, alias="FlowUnits")
-    code: Optional[str]
-    country: Optional[str]
-    global_disable: bool = Field(alias="globalDisable")
+    soil_types: list[int] = Field(default_factory=list, alias="SoilTypes")
+    flow_rates: list[int] = Field(default_factory=list, alias="FlowRates")
+    flow_units: list[int] = Field(default_factory=list, alias="FlowUnits")
+
+
+class Settings(BaseModel):
+    """Settings for the device."""
+
     num_programs: int = Field(alias="numPrograms")
     program_opt_out_mask: str = Field(alias="programOptOutMask")
-    soil_types: list[int] = Field(default_factory=[], alias="soilTypes")
+
+    code: Optional[str]
+    """Zip code for the device."""
+
+    country: Optional[str]
+    """Country location of the device."""
+
+    global_disable: bool = Field(alias="globalDisable")
+
+    # Program information
+    soil_types: list[int] = Field(default_factory=list, alias="soilTypes")
+    flow_rates: list[str] = Field(default_factory=list, alias="FlowRates")
+    flow_units: list[str] = Field(default_factory=list, alias="FlowUnits")
 
 
 class ScheduleAndSettings:
@@ -285,3 +300,10 @@ class WeatherAndStatus(BaseModel):
     controller: Optional[Controller] = Field(alias="Controller")
     forecasted_rain: Optional[dict[str, Any]] = Field(alias="ForecastedRain")
     weather: Optional[Weather] = Field(alias="Weather")
+
+
+class NetworkStatus(BaseModel):
+    """Get the device network status."""
+
+    network_up: bool = Field(alias="networkUp")
+    internet_up: bool = Field(alias="internetUp")

--- a/pyrainbird/exceptions.py
+++ b/pyrainbird/exceptions.py
@@ -1,0 +1,6 @@
+"""Exceptions from rainbird."""
+
+
+class RainbirdApiException(Exception):
+    """Exception from rainbird api."""
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@
 aiohttp==3.8.3
 responses==0.22.0
 parameterized==0.8.1
+pydantic==1.10.4
 pyflakes==2.5.0
 pytest-cov==4.0.0
 pytest-mock==3.10.0

--- a/test/async_client_test.py
+++ b/test/async_client_test.py
@@ -250,7 +250,7 @@ async def test_not_acknowledge_response(
         await controller.irrigate_zone(1, 30)
 
 
-async def test_get_wifi_settings(
+async def test_get_wifi_params(
     rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
     response: ResponseResult,
 ) -> None:
@@ -276,8 +276,8 @@ async def test_get_wifi_settings(
         }
     )
     response(aiohttp.web.Response(body=encrypt(payload, PASSWORD)))
-    settings = await controller.get_wifi_settings()
-    assert settings.dict() == {
+    params = await controller.get_wifi_params()
+    assert params.dict() == {
         "ap_security": "unknown",
         "ap_timeout_idle": 20,
         "ap_timeout_no_lan": 20,

--- a/test/rainbird_test.py
+++ b/test/rainbird_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from parameterized import parameterized
 
-from pyrainbird.rainbird import encode, decode
+from pyrainbird.rainbird import decode, encode
 
 
 def encode_name_func(testcase_func, param_num, param):


### PR DESCRIPTION
Add support for cloud commands to AsyncRainbirdController
- get weather and status (includes device, station, program names, etc)
- get schedule and settings
And additional local settings of some of the same options which includes the mac address, and country/zip used with weather/status commands.


These were captured using mitmproxy.