### PR TITLE
Update README and add new example command line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,8 @@
-![](http://iqweb.rainbird.com/iq/images/logos/rainbird.png) 
-# pyrainbird ![](https://img.shields.io/badge/python-2+-green.svg) [![Build Status](https://travis-ci.org/konikvranik/pyrainbird.svg?branch=master)](https://travis-ci.org/konikvranik/pyrainbird) [![Coverage Status](https://coveralls.io/repos/github/konikvranik/pyrainbird/badge.svg?branch=master)](https://coveralls.io/github/konikvranik/pyrainbird?branch=master)
-> Python module for interacting with WiFi LNK module of the Rain Bird Irrigation system
+# pyrainbird
 
-This project has no affiliation with Rain Bird. This module works with the Rain Bird LNK WiFi Module.
- For more information see https://www.rainbird.com/products/module-wi-fi-lnk
+Python module for interacting with [WiFi LNK](https://www.rainbird.com/products/module-wi-fi-lnk) module of the Rain Bird Irrigation system. This project has no affiliation with Rain Bird.
 
-----
+This module communicates directly towards the IP Address of the WiFi module. You can start/stop the irrigation, get the currently active zone, and other controller settings. This library currently only has very limited cloud support.
 
-This module communicates directly towards the IP Address of the WiFi module it does not support the cloud.
- You can start/stop the irrigation and get the currently active zone.
+See [examples](examples/) for additional details on how to use the APIs.
 
-I'm not a Python developer, so sorry for the bad code. I've developed it to control it from my domtica systems.
-
-
-**Please, feel free to contribute to this repo or chip in some cents for the effort and [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=TFXBL7W9VEQZC)
-
-On the bottom of the module is some test code. Feel free te test it with your own
-
-```python
-
-# Test for controller
-from pyrainbird import RainbirdController
-import time
-import logging
-
-logging.basicConfig(filename='pypython.log',level=logging.DEBUG)
-
-
-_LOGGER = logging.getLogger(__name__)
-_LOGGER .setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-ch.setFormatter(formatter)
-_LOGGER.addHandler(ch)
-
-controller = RainbirdController("####IP#####","####PASS#####")
-controller.irrigate_zone(4,5)
-time.sleep(4)
-controller.stop_irrigation()
-
-```
-
-See `examples/` for additional examples.

--- a/examples/rainbird_tool.py
+++ b/examples/rainbird_tool.py
@@ -8,7 +8,7 @@ commands for the tool.
 $ export RAINBIRD_SERVER=192.168.1.10
 $ export RAINBIRD_PASSWORD=mypass
 $ ./rainbird_tool --help
-$ ./rainbird_tool get_wifi_settings --help
+$ ./rainbird_tool get_wifi_settings
 ```
 """
 

--- a/examples/rainbird_tool.py
+++ b/examples/rainbird_tool.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""A command line tool for issuing commands to rainbird.
+
+All commands supported by `AsyncRainbirdController` are supported as
+commands for the tool.
+
+```
+$ export RAINBIRD_SERVER=192.168.1.10
+$ export RAINBIRD_PASSWORD=mypass
+$ ./rainbird_tool --help
+$ ./rainbird_tool get_wifi_settings --help
+```
+"""
+
+import asyncio
+import aiohttp
+import sys
+import inspect
+import argparse
+import logging
+
+from pyrainbird import async_client
+import logging
+import os
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--log-level', default='warning', choices=['debug', 'info', 'warning', 'error', 'critical'], help='The log level')
+
+    subcommand_parsers = parser.add_subparsers(title='Commands', dest='command', required=True)
+    for method_name in dir(async_client.AsyncRainbirdController):
+        if method_name.startswith("_"):
+            continue
+        method = getattr(async_client.AsyncRainbirdController, method_name)
+        if not callable(method):
+            continue
+
+        # Try to get the signature of the method
+        try:
+            sig = inspect.signature(method)
+        except ValueError:
+            # Skip the method if it has no signature
+            continue
+
+        # Create a parser for the method
+        method_parser = subcommand_parsers.add_parser(method_name, help=f'Call the {method_name} method')
+        method_parser.set_defaults(func=method)
+
+        # Get the arguments of the method
+        method_args = list(sig.parameters.keys())[1:]  # exclude 'self'
+        # Add the arguments to the parser
+        for arg in method_args:
+            param = sig.parameters[arg]
+            method_parser.add_argument(arg, default=param.default)
+
+    return parser.parse_args()
+
+
+async def main():
+    args = parse_args()
+    print(getattr(logging, args.log_level.upper()))
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+
+    host = os.environ["RAINBIRD_SERVER"]
+    password = os.environ["RAINBIRD_PASSWORD"]
+
+    async with aiohttp.ClientSession() as session:
+        client = async_client.CreateController(session, host, password)
+        method_args = {k: v for k, v in vars(args).items() if k != 'func' and k != 'command' and k != 'log_level'}
+        result = await args.func(client, **method_args)
+        print(result)
+
+# Run the main function if this script is run
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
Add a command line tool for communicating with rainbird devices.

Example usage:
```
$ export RAINBIRD_SERVER=192.168.1.10
$ export RAINBIRD_PASSWORD=mypass
$ ./rainbird_tool --help
$ ./rainbird_tool get_wifi_settings
```