### PR TITLE
Add schedule API for testing and adjust schedule object output

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -278,7 +278,7 @@ class AsyncRainbirdController:
     async def get_weather_and_status(
         self, stick_id: str, country: str, zip_code: str
     ) -> WeatherAndStatus:
-        """Request the schedule and settings from the cloud.
+        """Request the weather and status of the device.
 
         The results include things like custom station names, program names, etc.
         """
@@ -307,6 +307,14 @@ class AsyncRainbirdController:
                 resp["major"], resp["minor"], resp["patch"]
             ),
             "ControllerFirmwareVersion",
+        )
+
+    async def get_schedule(self, command_code: str) -> dict[str, Any]:
+        """Run the schedule command for the specified raw command code."""
+        return await self._process_command(
+            lambda resp: resp,
+            "RetrieveSchedule",
+            command_code,
         )
 
     async def test_command_support(self, command_id: int) -> bool:

--- a/pyrainbird/rainbird.py
+++ b/pyrainbird/rainbird.py
@@ -24,29 +24,38 @@ def decode_schedule(data: str, cmd_template: dict[str, Any]) -> dict[str, Any]:
     if subcommand == 0:
         # Delay, Snooze, Rainsensor
         return {
-            "stationDelay": int(rest[0:4]),
-            "snooze": int(rest[4:6]),
-            "rainSensor": int(rest[6:8]),
+            "controllerInfo": {
+                "stationDelay": int(rest[0:4]),
+                "rainDelay": int(rest[4:6]),
+                "rainSensor": int(rest[6:8]),
+            }
         }
 
     if subcommand & 16 == 16:
         program = subcommand & ~16
         fields = list(int(rest[i : i + 2], 16) for i in range(0, len(rest), 2))
         return {
-            "program": program,
-            "daysOfWeekMask": fields[0],
-            "period": fields[1],
-            "synchro": fields[2],
-            "permanentDaysOff": fields[3],
-            "reserved": fields[4],
-            "frequency": fields[5],
+            "programInfo": {
+                "program": program,
+                "daysOfWeekMask": fields[0],
+                "period": fields[1],
+                "synchro": fields[2],
+                "permanentDaysOff": fields[3],
+                "reserved": fields[4],
+                "frequency": fields[5],
+            }
         }
 
     if subcommand & 96 == 96:
         program = subcommand & ~96
         # Note: 65535 is disabled
         entries = list(int(rest[i : i + 4], 16) for i in range(0, len(rest), 4))
-        return {"program": program, "startTime": entries}
+        return {
+            "programStartInfo": {
+                "program": program,
+                "startTime": entries,
+            }
+        }
 
     if subcommand & 128 == 128:
         station = subcommand & ~128

--- a/tests/testdata/schedule.yaml
+++ b/tests/testdata/schedule.yaml
@@ -1,14 +1,14 @@
 data:
   - A0000000000400
   - A000106A0601006401
-  - A000116A0300006400
+  - A000117F0300002D00
   - A00012000300006400
   - A0006000F0FFFFFFFFFFFF
-  - A00061FFFFFFFFFFFFFFFF
+  - A000610168FFFFFFFFFFFF
   - A00062FFFFFFFFFFFFFFFF
-  - A00080001900000000001400000000
-  - A00081000700000000001400000000
-  - A00082000A00000000000000000000
+  - A00080001900010000001400020000
+  - A00081000700030000001400040000
+  - A00082000A00060000000000000000
   - A00083000000000000000000000000
   - A00084000000000000000000000000
   - A00085000000000000000000000000
@@ -18,58 +18,67 @@ data:
   - "0131"
 decoded_data:
   - type: RetrieveScheduleResponse
-    stationDelay: 0
-    rainSensor: 0
-    snooze: 4
+    controllerInfo:
+      stationDelay: 0
+      rainSensor: 0
+      rainDelay: 4
   - type: RetrieveScheduleResponse
-    program: 0
-    daysOfWeekMask: 106
-    period: 6
-    synchro: 1
-    permanentDaysOff: 0
-    reserved: 100
-    frequency: 1
+    programInfo:
+      program: 0
+      daysOfWeekMask: 106
+      period: 6
+      synchro: 1
+      permanentDaysOff: 0
+      reserved: 100
+      frequency: 1
   - type: RetrieveScheduleResponse
-    program: 1
-    daysOfWeekMask: 106
-    period: 3
-    synchro: 0
-    permanentDaysOff: 0
-    reserved: 100
-    frequency: 0
+    programInfo:
+      program: 1
+      daysOfWeekMask: 127  # Every day of week
+      period: 3
+      synchro: 0
+      permanentDaysOff: 0
+      reserved: 45
+      frequency: 0
   - type: RetrieveScheduleResponse
-    program: 2
-    daysOfWeekMask: 0
-    period: 3
-    synchro: 0
-    permanentDaysOff: 0
-    reserved: 100
-    frequency: 0
+    programInfo:
+      program: 2
+      daysOfWeekMask: 0
+      period: 3
+      synchro: 0
+      permanentDaysOff: 0
+      reserved: 100
+      frequency: 0
   - type: RetrieveScheduleResponse
-    program: 0
-    startTime: [240, 65535, 65535, 65535]
+    programStartInfo:
+      program: 0
+      # 4am
+      startTime: [240, 65535, 65535, 65535]
   - type: RetrieveScheduleResponse
-    program: 1
-    startTime: [65535, 65535, 65535, 65535]
+    programStartInfo:
+      program: 1
+      # 6am
+      startTime: [360, 65535, 65535, 65535]
   - type: RetrieveScheduleResponse
-    program: 2
-    startTime: [65535, 65535, 65535, 65535]
+    programStartInfo:
+      program: 2
+      startTime: [65535, 65535, 65535, 65535]
   - type: RetrieveScheduleResponse
     durations:
       - zone: 0
-        durations: [25, 0, 0]
+        durations: [25, 1, 0]  # Program 0, 1, 2
       - zone: 1
-        durations: [20, 0, 0]
+        durations: [20, 2, 0]
   - type: RetrieveScheduleResponse
     durations:
       - zone: 2
-        durations: [7, 0, 0]
+        durations: [7, 3, 0]
       - zone: 3
-        durations: [20, 0, 0]
+        durations: [20, 4, 0]
   - type: RetrieveScheduleResponse
     durations:
       - zone: 4
-        durations: [10, 0, 0]
+        durations: [10, 6, 0]
       - zone: 5
         durations: [0, 0, 0]
   - type: RetrieveScheduleResponse


### PR DESCRIPTION
Add schedule API for testing and adjust schedule object output. The schedule objects now output a submessage
to make it easier to merge and parse within pydantic, which will happen in future PRs.

For now, the schedule API can be called multiple times from the command line tool manually.