### PR TITLE
Cleanup internal resources for requests and responses

### DIFF
--- a/pyrainbird/__init__.py
+++ b/pyrainbird/__init__.py
@@ -147,7 +147,7 @@ class RainbirdController:
         )
 
     def command(self, command, *args):
-        data = rainbird.encode(command, *args)
+        data = rainbird.encode(f"{command}Request", *args)
         self.logger.debug("Request to line: " + str(data))
         decrypted_data = self.rainbird_client.request(
             data,

--- a/pyrainbird/__init__.py
+++ b/pyrainbird/__init__.py
@@ -11,7 +11,7 @@ from pyrainbird.data import (
     States,
     WaterBudget,
 )
-from pyrainbird.resources import RAINBIRD_COMMANDS
+from pyrainbird.resources import RAINBIRD_COMMANDS, RAINBIRD_RESPONSES_BY_ID
 
 from . import rainbird
 from .client import RainbirdClient
@@ -50,7 +50,7 @@ class RainbirdController:
     def get_available_stations(self, page=_DEFAULT_PAGE):
         mask = (
             "%%0%dX"
-            % RAINBIRD_COMMANDS["ControllerResponses"]["83"]["setStations"]["length"]
+            % RAINBIRD_RESPONSES_BY_ID["83"]["setStations"]["length"]
         )
         return self._process_command(
             lambda resp: AvailableStations(
@@ -151,7 +151,7 @@ class RainbirdController:
         self.logger.debug("Request to line: " + str(data))
         decrypted_data = self.rainbird_client.request(
             data,
-            RAINBIRD_COMMANDS["ControllerCommands"]["%sRequest" % command]["length"],
+            RAINBIRD_COMMANDS["%sRequest" % command]["length"],
         )
         self.logger.debug("Response from line: " + str(decrypted_data))
         if decrypted_data is None:
@@ -160,14 +160,14 @@ class RainbirdController:
         decoded = rainbird.decode(decrypted_data)
         if (
             decrypted_data[:2]
-            != RAINBIRD_COMMANDS["ControllerCommands"]["%sRequest" % command][
+            != RAINBIRD_COMMANDS["%sRequest" % command][
                 "response"
             ]
         ):
             raise Exception(
                 "Status request failed with wrong response! Requested %s but got %s:\n%s"
                 % (
-                    RAINBIRD_COMMANDS["ControllerCommands"]["%sRequest" % command][
+                    RAINBIRD_COMMANDS["%sRequest" % command][
                         "response"
                     ],
                     decrypted_data[:2],
@@ -183,8 +183,8 @@ class RainbirdController:
             funct(response)
             if response is not None
             and response["type"]
-            == RAINBIRD_COMMANDS["ControllerResponses"][
-                RAINBIRD_COMMANDS["ControllerCommands"][cmd + "Request"]["response"]
+            == RAINBIRD_RESPONSES_BY_ID[
+                RAINBIRD_COMMANDS[cmd + "Request"]["response"]
             ]["type"]
             else response
         )
@@ -192,7 +192,7 @@ class RainbirdController:
     def _update_irrigation_state(self, page=_DEFAULT_PAGE):
         mask = (
             "%%0%dX"
-            % RAINBIRD_COMMANDS["ControllerResponses"]["BF"]["activeStations"]["length"]
+            % RAINBIRD_RESPONSES_BY_ID["BF"]["activeStations"]["length"]
         )
         result = self._process_command(
             lambda resp: States((mask % resp["activeStations"])[:4]),

--- a/pyrainbird/rainbird.py
+++ b/pyrainbird/rainbird.py
@@ -101,11 +101,10 @@ def decode(data: str) -> dict[str, Any]:
 
 def encode(command: str, *args) -> str:
     """Encode a rainbird tunnelSip command request."""
-    request_command = "%sRequest" % command
-    if not (command_set := RAINBIRD_COMMANDS.get(request_command)):
+    if not (command_set := RAINBIRD_COMMANDS.get(command)):
         raise Exception(
             "Command %s not available. Existing commands: %s"
-            % (request_command, RAINBIRD_COMMANDS["ControllerCommands"])
+            % (command, RAINBIRD_COMMANDS.keys())
         )
     cmd_code = command_set["command"]
     if len(args) > command_set["length"] - 1:

--- a/pyrainbird/resources/__init__.py
+++ b/pyrainbird/resources/__init__.py
@@ -1,14 +1,16 @@
 """Resources related to rainbird devices."""
 
-import yaml
-from pkg_resources import resource_stream
 from typing import Any
 
-COMMAND = "command"
+import yaml
+from pkg_resources import resource_stream
 
+COMMAND = "command"
 TYPE = "type"
+LENGTH = "length"
+RESPONSE = "response"
 # Fields in the command template that should not be encoded
-RESERVED_FIELDS = [ "command", "type", "length" ]
+RESERVED_FIELDS = [COMMAND, TYPE, LENGTH, RESPONSE]
 
 SIP_COMMANDS = yaml.load(
     resource_stream("pyrainbird.resources", "sipcommands.yaml"), Loader=yaml.FullLoader
@@ -17,9 +19,10 @@ RAINBIRD_MODELS = yaml.load(
     resource_stream("pyrainbird.resources", "models.yaml"), Loader=yaml.FullLoader
 )
 
+
 def build_id_map(commands: dict[str, Any]) -> dict[str, Any]:
     """Build an ID based map for the specified command struct."""
-    return  {
+    return {
         content[COMMAND]: {
             **content,
             TYPE: key,
@@ -27,11 +30,12 @@ def build_id_map(commands: dict[str, Any]) -> dict[str, Any]:
         for key, content in commands.items()
     }
 
+
 CONTROLLER_COMMANDS = "ControllerCommands"
 CONTROLLER_RESPONSES = "ControllerResponses"
 
-RAINBIRD_COMMANDS = { **SIP_COMMANDS[CONTROLLER_COMMANDS] }
-RAINBIRD_RESPONSES = { **SIP_COMMANDS[CONTROLLER_RESPONSES] }
+RAINBIRD_COMMANDS = {**SIP_COMMANDS[CONTROLLER_COMMANDS]}
+RAINBIRD_RESPONSES = {**SIP_COMMANDS[CONTROLLER_RESPONSES]}
 
 RAINBIRD_COMMANDS_BY_ID = build_id_map(SIP_COMMANDS[CONTROLLER_COMMANDS])
 RAINBIRD_RESPONSES_BY_ID = build_id_map(SIP_COMMANDS[CONTROLLER_RESPONSES])

--- a/pyrainbird/resources/__init__.py
+++ b/pyrainbird/resources/__init__.py
@@ -1,29 +1,37 @@
+"""Resources related to rainbird devices."""
+
 import yaml
 from pkg_resources import resource_stream
+from typing import Any
 
-_SIP_COMMANDS = yaml.load(
+COMMAND = "command"
+
+TYPE = "type"
+# Fields in the command template that should not be encoded
+RESERVED_FIELDS = [ "command", "type", "length" ]
+
+SIP_COMMANDS = yaml.load(
     resource_stream("pyrainbird.resources", "sipcommands.yaml"), Loader=yaml.FullLoader
 )
 RAINBIRD_MODELS = yaml.load(
     resource_stream("pyrainbird.resources", "models.yaml"), Loader=yaml.FullLoader
 )
 
-# Fields in the template that should not be encoded
-RESERVED_FIELDS = [ "command", "type", "length" ]
+def build_id_map(commands: dict[str, Any]) -> dict[str, Any]:
+    """Build an ID based map for the specified command struct."""
+    return  {
+        content[COMMAND]: {
+            **content,
+            TYPE: key,
+        }
+        for key, content in commands.items()
+    }
 
-RAINBIRD_COMMANDS = { **_SIP_COMMANDS['ControllerCommands'] }
-RAINBIRD_COMMANDS_BY_ID = {
-    request["command"]: {
-        **request,
-        "type": request_key,
-    }
-    for request_key, request in _SIP_COMMANDS['ControllerCommands'].items()
-}
-RAINBIRD_RESPONSES = { **_SIP_COMMANDS['ControllerResponses'] }
-RAINBIRD_RESPONSES_BY_ID = {
-    response["command"]: {
-        **response,
-        "type": response_key,
-    }
-    for response_key, response in _SIP_COMMANDS['ControllerResponses'].items()
-}
+CONTROLLER_COMMANDS = "ControllerCommands"
+CONTROLLER_RESPONSES = "ControllerResponses"
+
+RAINBIRD_COMMANDS = { **SIP_COMMANDS[CONTROLLER_COMMANDS] }
+RAINBIRD_RESPONSES = { **SIP_COMMANDS[CONTROLLER_RESPONSES] }
+
+RAINBIRD_COMMANDS_BY_ID = build_id_map(SIP_COMMANDS[CONTROLLER_COMMANDS])
+RAINBIRD_RESPONSES_BY_ID = build_id_map(SIP_COMMANDS[CONTROLLER_RESPONSES])

--- a/pyrainbird/resources/__init__.py
+++ b/pyrainbird/resources/__init__.py
@@ -1,10 +1,29 @@
 import yaml
 from pkg_resources import resource_stream
 
-# parameters in number of nibbles (based on string representations of SIP bytes), total lengths in number of SIP bytes
-RAINBIRD_COMMANDS = yaml.load(
+_SIP_COMMANDS = yaml.load(
     resource_stream("pyrainbird.resources", "sipcommands.yaml"), Loader=yaml.FullLoader
 )
 RAINBIRD_MODELS = yaml.load(
     resource_stream("pyrainbird.resources", "models.yaml"), Loader=yaml.FullLoader
 )
+
+# Fields in the template that should not be encoded
+RESERVED_FIELDS = [ "command", "type", "length" ]
+
+RAINBIRD_COMMANDS = { **_SIP_COMMANDS['ControllerCommands'] }
+RAINBIRD_COMMANDS_BY_ID = {
+    request["command"]: {
+        **request,
+        "type": request_key,
+    }
+    for request_key, request in _SIP_COMMANDS['ControllerCommands'].items()
+}
+RAINBIRD_RESPONSES = { **_SIP_COMMANDS['ControllerResponses'] }
+RAINBIRD_RESPONSES_BY_ID = {
+    response["command"]: {
+        **response,
+        "type": response_key,
+    }
+    for response_key, response in _SIP_COMMANDS['ControllerResponses'].items()
+}

--- a/pyrainbird/resources/sipcommands.yaml
+++ b/pyrainbird/resources/sipcommands.yaml
@@ -133,24 +133,24 @@ ControllerCommands:
   # LogEntriesRequest: 70
 
 ControllerResponses:
-  '00':
+  NotAcknowledgeResponse:
+    command: '00'
     length: 3
-    type: NotAcknowledgeResponse
     commandEcho:
       position: 2
       length: 2
     NAKCode:
       position: 4
       length: 2
-  '01':
+  AcknowledgeResponse:
+    command: '01'
     length: 2
-    type: AcknowledgeResponse
     commandEcho:
       position: 2
       length: 2
-  '82':
+  ModelAndVersionResponse:
+    command: '82'
     length: 5
-    type: ModelAndVersionResponse
     modelID:
       position: 2
       length: 4
@@ -160,33 +160,33 @@ ControllerResponses:
     protocolRevisionMinor:
       position: 8
       length: 2
-  '83':
+  AvailableStationsResponse:
+    command: '83'
     length: 6
-    type: AvailableStationsResponse
     pageNumber:
       position: 2
       length: 2
     setStations:
       position: 4
       length: 8
-  '84':
+  CommandSupportResponse:
+    command: '84'
     length: 3
-    type: CommandSupportResponse
     commandEcho:
       position: 2
       length: 2
     support:
       position: 4
       length: 2
-  '85':
+  SerialNumberResponse:
+    command: '85'
     length: 9
-    type: SerialNumberResponse
     serialNumber:
       position: 2
       length: 16
-  '8B':
+  ControllerFirmwareVersionResponse:
+    command: '8B'
     length: 5
-    type: ControllerFirmwareVersion
     major:
       position: 2
       length: 2
@@ -197,9 +197,9 @@ ControllerResponses:
       position: 6
       length: 4
   # UniversalMessageTransportResponse 8C
-  '90':
+  CurrentTimeResponse:
+    command: '90'
     length: 4
-    type: CurrentTimeResponse
     hour:
       position: 2
       length: 2
@@ -209,9 +209,9 @@ ControllerResponses:
     second:
       position: 6
       length: 2
-  '92':
+  CurrentDateResponse:
+    command: '92'
     length: 4
-    type: CurrentDateResponse
     day:
       position: 2
       length: 2
@@ -221,21 +221,22 @@ ControllerResponses:
     year:
       position: 5
       length: 3
-  'A0':
+  RetrieveScheduleResponse:
+    command: 'A0'
     length: 18
-    type: RetrieveScheduleResponse
     # Requires a custom processor that can't be expressed in yaml
     decoder: decode_schedule
-  'B0':
+  WaterBudgetResponse:
+    command: 'B0'
     length: 4
-    type: WaterBudgetResponse
     programCode:
       position: 2
       length: 2
     seasonalAdjust:
       position: 4
       length: 4
-  'B2':
+  ZonesSeasonalAdjustFactorResponse:
+    command: 'B2'
     length: 18
     type: ZonesSeasonalAdjustFactorResponse
     programCode:
@@ -244,46 +245,47 @@ ControllerResponses:
     stationsSA:
       position: 4
       length: 32
-  'B6':
+  RainDelaySettingResponse:
+    command: 'B6'
     length: 3
     type: RainDelaySettingResponse
     delaySetting:
       position: 2
       length: 4
   # CurrentQueueResponse BB
-  'BE':
+  CurrentRainSensorStateResponse:
+    command: 'BE'
     length: 2
-    type: CurrentRainSensorStateResponse
     sensorState:
       position: 2
       length: 2
-  'BF':
+  CurrentStationsActiveResponse:
+    command: 'BF'
     length: 6
-    type: CurrentStationsActiveResponse
     pageNumber:
       position: 2
       length: 2
     activeStations:
       position: 4
       length: 8
-  'C8':
+  CurrentIrrigationStateResponse:
+    command: 'C8'
     length: 2
-    type: CurrentIrrigationStateResponse
     irrigationState:
       position: 2
       length: 2
-  'CA':
+  ControllerEventTimestampResponse:
+    command: 'CA'
     length: 6
-    type: ControllerEventTimestampResponse
     eventId:
       position: 2
       length: 2
     timestamp:
       position: 4
       length: 8
-  'CC':
+  CombinedControllerStateResponse:
+    command: 'CC'
     length: 16
-    type: CombinedControllerStateResponse
     hour:
       position: 2
       length: 2

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -8,7 +8,6 @@ import aiohttp
 import pytest
 
 from pyrainbird import (
-    RAINBIRD_COMMANDS,
     AvailableStations,
     ModelAndVersion,
     WaterBudget,
@@ -17,6 +16,7 @@ from pyrainbird.async_client import AsyncRainbirdClient, AsyncRainbirdController
 from pyrainbird.data import SoilType
 from pyrainbird.encryption import encrypt
 from pyrainbird.exceptions import RainbirdApiException, RainbirdAuthException
+from pyrainbird.resources import RAINBIRD_RESPONSES_BY_ID, RESERVED_FIELDS
 
 from .conftest import LENGTH, PASSWORD, REQUEST, RESPONSE, RESULT_DATA, ResponseResult
 
@@ -61,10 +61,10 @@ def mock_api_response(response: ResponseResult) -> Callable[[...], Awaitable[Non
     """Fixture to construct a fake API response."""
 
     def _put_result(command: str, **kvargs) -> None:
-        resp = RAINBIRD_COMMANDS["ControllerResponses"][command]
+        resp = RAINBIRD_RESPONSES_BY_ID[command]
         data = command + ("00" * (resp["length"] - 1))
         for k in resp:
-            if k in ["type", "length"]:
+            if k in RESERVED_FIELDS:
                 continue
             param_template = "%%0%dX" % (resp[k]["length"])
             start_ = resp[k]["position"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,12 +5,12 @@ import responses
 
 from pyrainbird import (
     RainbirdController,
-    RAINBIRD_COMMANDS,
     ModelAndVersion,
     AvailableStations,
     CommandSupport,
     WaterBudget,
 )
+from pyrainbird.resources import RAINBIRD_RESPONSES_BY_ID, RESERVED_FIELDS
 from pyrainbird.encryption import encrypt
 
 MOCKED_RAINBIRD_URL = "rainbird.local"
@@ -159,10 +159,10 @@ class TestCase(unittest.TestCase):
 
 
 def mock_response(command, **kvargs):
-    resp = RAINBIRD_COMMANDS["ControllerResponses"][command]
+    resp = RAINBIRD_RESPONSES_BY_ID[command]
     data = command + ("00" * (resp["length"] - 1))
     for k in resp:
-        if k in ["type", "length"]:
+        if k in RESERVED_FIELDS:
             continue
         param_template = "%%0%dX" % (resp[k]["length"])
         start_ = resp[k]["position"]

--- a/tests/test_rainbird.py
+++ b/tests/test_rainbird.py
@@ -56,4 +56,4 @@ class TestSequence(unittest.TestCase):
         name_func=encode_name_func,
     )
     def test_encode(self, expected, command, *vargs):
-        self.assertEqual(expected, encode(command, *vargs))
+        self.assertEqual(expected, encode(f"{command}Request", *vargs))

--- a/tests/testdata/settings.yaml
+++ b/tests/testdata/settings.yaml
@@ -12,7 +12,7 @@ decoded_data:
   - type: AvailableStationsResponse
     setStations: 0x3F000000
     pageNumber: 0
-  - type: ControllerFirmwareVersion
+  - type: ControllerFirmwareVersionResponse
     major: 1
     minor: 47
     patch: 0


### PR DESCRIPTION
Update the rainbird request/response objects to be in the same format, so that we can later encode/decode them using the same functions.