### PR TITLE
Combine request and response encoding/decoding

### DIFF
--- a/pyrainbird/__init__.py
+++ b/pyrainbird/__init__.py
@@ -11,7 +11,7 @@ from pyrainbird.data import (
     States,
     WaterBudget,
 )
-from pyrainbird.resources import RAINBIRD_COMMANDS, RAINBIRD_RESPONSES_BY_ID
+from pyrainbird.resources import RAINBIRD_COMMANDS, RAINBIRD_COMMANDS_BY_ID
 
 from . import rainbird
 from .client import RainbirdClient
@@ -48,10 +48,7 @@ class RainbirdController:
         )
 
     def get_available_stations(self, page=_DEFAULT_PAGE):
-        mask = (
-            "%%0%dX"
-            % RAINBIRD_RESPONSES_BY_ID["83"]["setStations"]["length"]
-        )
+        mask = "%%0%dX" % RAINBIRD_COMMANDS_BY_ID["83"]["setStations"]["length"]
         return self._process_command(
             lambda resp: AvailableStations(
                 mask % resp["setStations"], page=resp["pageNumber"]
@@ -158,18 +155,11 @@ class RainbirdController:
             self.logger.warn("Empty response from controller")
             return None
         decoded = rainbird.decode(decrypted_data)
-        if (
-            decrypted_data[:2]
-            != RAINBIRD_COMMANDS["%sRequest" % command][
-                "response"
-            ]
-        ):
+        if decrypted_data[:2] != RAINBIRD_COMMANDS["%sRequest" % command]["response"]:
             raise Exception(
                 "Status request failed with wrong response! Requested %s but got %s:\n%s"
                 % (
-                    RAINBIRD_COMMANDS["%sRequest" % command][
-                        "response"
-                    ],
+                    RAINBIRD_COMMANDS["%sRequest" % command]["response"],
                     decrypted_data[:2],
                     decoded,
                 )
@@ -183,17 +173,14 @@ class RainbirdController:
             funct(response)
             if response is not None
             and response["type"]
-            == RAINBIRD_RESPONSES_BY_ID[
-                RAINBIRD_COMMANDS[cmd + "Request"]["response"]
-            ]["type"]
+            == RAINBIRD_COMMANDS_BY_ID[RAINBIRD_COMMANDS[cmd + "Request"]["response"]][
+                "type"
+            ]
             else response
         )
 
     def _update_irrigation_state(self, page=_DEFAULT_PAGE):
-        mask = (
-            "%%0%dX"
-            % RAINBIRD_RESPONSES_BY_ID["BF"]["activeStations"]["length"]
-        )
+        mask = "%%0%dX" % RAINBIRD_COMMANDS_BY_ID["BF"]["activeStations"]["length"]
         result = self._process_command(
             lambda resp: States((mask % resp["activeStations"])[:4]),
             "CurrentStationsActive",

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -32,7 +32,7 @@ from .data import (
     ZipCode,
 )
 from .exceptions import RainbirdApiException, RainbirdAuthException
-from .resources import LENGTH, RAINBIRD_COMMANDS, RAINBIRD_RESPONSES, RESPONSE
+from .resources import LENGTH, RAINBIRD_COMMANDS, RESPONSE
 
 _LOGGER = logging.getLogger(__name__)
 T = TypeVar("T")
@@ -130,7 +130,7 @@ class AsyncRainbirdController:
         """Get the available stations."""
         mask = (
             "%%0%dX"
-            % RAINBIRD_RESPONSES["AvailableStationsResponse"]["setStations"][LENGTH]
+            % RAINBIRD_COMMANDS["AvailableStationsResponse"]["setStations"][LENGTH]
         )
         return await self._process_command(
             lambda resp: AvailableStations(
@@ -214,7 +214,7 @@ class AsyncRainbirdController:
         """Return the current state of the zone."""
         mask = (
             "%%0%dX"
-            % RAINBIRD_RESPONSES["CurrentStationsActiveResponse"]["activeStations"][
+            % RAINBIRD_COMMANDS["CurrentStationsActiveResponse"]["activeStations"][
                 LENGTH
             ]
         )

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -228,7 +228,6 @@ class Settings(BaseModel):
     @root_validator(pre=True)
     def _soil_type(cls, values: dict[str, Any]):
         """Validate different ways the SoilTypes parameter is handled."""
-        print("values=", values)
         if soil_type := values.get("soilTypes"):
             values["SoilTypes"] = soil_type
         return values

--- a/pyrainbird/exceptions.py
+++ b/pyrainbird/exceptions.py
@@ -8,3 +8,6 @@ class RainbirdApiException(Exception):
 class RainbirdAuthException(Exception):
     """Authentication exception from rainbird API."""
 
+
+class RainbirdCodingException(Exception):
+    """Error while encoding or decoding objects."""

--- a/pyrainbird/rainbird.py
+++ b/pyrainbird/rainbird.py
@@ -132,6 +132,7 @@ def encode_command(command_set: dict[str, Any], *args) -> str:
         )
 
     if length == 1 or "parameter" in command_set or "parameterOne" in command_set:
+        # TODO: Replace old style encoding with new encoding below
         params = (cmd_code,) + tuple(map(lambda x: int(x), args))
         arg_placeholders = (
             ("%%0%dX" % ((length - len(args)) * 2)) if len(args) > 0 else ""

--- a/pyrainbird/rainbird.py
+++ b/pyrainbird/rainbird.py
@@ -1,10 +1,19 @@
 """Library for encoding and decoding rainbird tunnelSip commands."""
 
-from collections.abc import Callable
 import logging
+from collections.abc import Callable
 from typing import Any
 
-from .resources import RAINBIRD_COMMANDS, RAINBIRD_RESPONSES_BY_ID
+from .exceptions import RainbirdCodingException
+from .resources import (
+    DECODER,
+    LENGTH,
+    POSITION,
+    RAINBIRD_COMMANDS,
+    RAINBIRD_COMMANDS_BY_ID,
+    RESERVED_FIELDS,
+    TYPE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -13,10 +22,12 @@ def decode_template(data: str, cmd_template: dict[str, Any]) -> dict[str, int]:
     """Decode the command from the template in yaml."""
     result = {}
     for k, v in cmd_template.items():
-        if isinstance(v, dict) and "position" in v and "length" in v:
-            position_ = v["position"]
-            length_ = v["length"]
-            result[k] = int(data[position_ : position_ + length_], 16)
+        if (
+            isinstance(v, dict)
+            and (position := v.get(POSITION))
+            and (length := v.get(LENGTH))
+        ):
+            result[k] = int(data[position : position + length], 16)
     return result
 
 
@@ -92,28 +103,58 @@ DECODERS: dict[str, Callable[[str, dict[str, Any]], dict[str, Any]]] = {
 def decode(data: str) -> dict[str, Any]:
     """Decode a rainbird tunnelSip command response."""
     command_code = data[:2]
-    if not (cmd_template := RAINBIRD_RESPONSES_BY_ID.get(command_code)):
-        _LOGGER.warning("Unrecognized server response code '%s' from '%s'", command_code, data)
+    if not (cmd_template := RAINBIRD_COMMANDS_BY_ID.get(command_code)):
+        _LOGGER.warning(
+            "Unrecognized server response code '%s' from '%s'", command_code, data
+        )
         return {"data": data}
-    decoder = DECODERS[cmd_template.get("decoder", DEFAULT_DECODER)]
-    return {"type": cmd_template["type"], **decoder(data, cmd_template)}
+    decoder = DECODERS[cmd_template.get(DECODER, DEFAULT_DECODER)]
+    return {TYPE: cmd_template[TYPE], **decoder(data, cmd_template)}
 
 
 def encode(command: str, *args) -> str:
     """Encode a rainbird tunnelSip command request."""
     if not (command_set := RAINBIRD_COMMANDS.get(command)):
-        raise Exception(
-            "Command %s not available. Existing commands: %s"
-            % (command, RAINBIRD_COMMANDS.keys())
+        raise RainbirdCodingException(
+            f"Command {command} not available. Existing commands: {RAINBIRD_COMMANDS.keys()}"
         )
+    return encode_command(command_set, *args)
+
+
+def encode_command(command_set: dict[str, Any], *args) -> str:
+    """Encode a rainbird tunnelSip command request."""
     cmd_code = command_set["command"]
-    if len(args) > command_set["length"] - 1:
-        raise Exception(
-            "Too much parameters. %d expected:\n%s"
-            % (command_set["length"] - 1, command_set)
+    if not (length := command_set[LENGTH]):
+        raise RainbirdCodingException(f"Unable to encode command '{command}'")
+    if len(args) > length:
+        raise RainbirdCodingException(
+            f"Too many parameters. {length} expected: {command_set}"
         )
-    params = (cmd_code,) + tuple(map(lambda x: int(x), args))
-    arg_placeholders = (
-        ("%%0%dX" % ((command_set["length"] - len(args)) * 2)) if len(args) > 0 else ""
-    ) + ("%02X" * (len(args) - 1))
-    return ("%s" + arg_placeholders) % (params)
+
+    if length == 1 or "parameter" in command_set or "parameterOne" in command_set:
+        params = (cmd_code,) + tuple(map(lambda x: int(x), args))
+        arg_placeholders = (
+            ("%%0%dX" % ((length - len(args)) * 2)) if len(args) > 0 else ""
+        ) + ("%02X" * (len(args) - 1))
+        return ("%s" + arg_placeholders) % (params)
+
+    data = cmd_code + ("00" * (length - 1))
+    args_list = list(args)
+    for k in command_set:
+        if k in RESERVED_FIELDS:
+            continue
+        command_arg = command_set[k]
+        command_arg_length = command_arg[LENGTH]
+        arg = args_list.pop(0)
+        if isinstance(arg, str):
+            arg = int(arg, 16)
+        param_template = "%%0%dX" % (command_arg_length)
+        start_ = command_arg[POSITION]
+        end_ = start_ + command_arg_length
+        data = "%s%s%s" % (
+            data[:start_],
+            # TODO: Replace with kwargs
+            (param_template % arg),
+            data[end_:],
+        )
+    return data

--- a/pyrainbird/rainbird.py
+++ b/pyrainbird/rainbird.py
@@ -125,7 +125,7 @@ def encode_command(command_set: dict[str, Any], *args) -> str:
     """Encode a rainbird tunnelSip command request."""
     cmd_code = command_set["command"]
     if not (length := command_set[LENGTH]):
-        raise RainbirdCodingException(f"Unable to encode command '{command}'")
+        raise RainbirdCodingException(f"Unable to encode command missing length: {command_set}")
     if len(args) > length:
         raise RainbirdCodingException(
             f"Too many parameters. {length} expected: {command_set}"

--- a/pyrainbird/resources/__init__.py
+++ b/pyrainbird/resources/__init__.py
@@ -6,8 +6,6 @@ import yaml
 from pkg_resources import resource_stream
 
 COMMAND = "command"
-
-COMMAND = "command"
 TYPE = "type"
 LENGTH = "length"
 RESPONSE = "response"

--- a/pyrainbird/resources/__init__.py
+++ b/pyrainbird/resources/__init__.py
@@ -6,6 +6,8 @@ import yaml
 from pkg_resources import resource_stream
 
 COMMAND = "command"
+
+COMMAND = "command"
 TYPE = "type"
 LENGTH = "length"
 RESPONSE = "response"

--- a/pyrainbird/resources/__init__.py
+++ b/pyrainbird/resources/__init__.py
@@ -9,8 +9,10 @@ COMMAND = "command"
 TYPE = "type"
 LENGTH = "length"
 RESPONSE = "response"
+POSITION = "position"
+DECODER = "decoder"
 # Fields in the command template that should not be encoded
-RESERVED_FIELDS = [COMMAND, TYPE, LENGTH, RESPONSE]
+RESERVED_FIELDS = [COMMAND, TYPE, LENGTH, RESPONSE, DECODER]
 
 SIP_COMMANDS = yaml.load(
     resource_stream("pyrainbird.resources", "sipcommands.yaml"), Loader=yaml.FullLoader
@@ -34,8 +36,11 @@ def build_id_map(commands: dict[str, Any]) -> dict[str, Any]:
 CONTROLLER_COMMANDS = "ControllerCommands"
 CONTROLLER_RESPONSES = "ControllerResponses"
 
-RAINBIRD_COMMANDS = {**SIP_COMMANDS[CONTROLLER_COMMANDS]}
-RAINBIRD_RESPONSES = {**SIP_COMMANDS[CONTROLLER_RESPONSES]}
-
-RAINBIRD_COMMANDS_BY_ID = build_id_map(SIP_COMMANDS[CONTROLLER_COMMANDS])
-RAINBIRD_RESPONSES_BY_ID = build_id_map(SIP_COMMANDS[CONTROLLER_RESPONSES])
+RAINBIRD_COMMANDS = {
+    **SIP_COMMANDS[CONTROLLER_COMMANDS],
+    **SIP_COMMANDS[CONTROLLER_RESPONSES],
+}
+RAINBIRD_COMMANDS_BY_ID = {
+    **build_id_map(SIP_COMMANDS[CONTROLLER_COMMANDS]),
+    **build_id_map(SIP_COMMANDS[CONTROLLER_RESPONSES]),
+}

--- a/pyrainbird/resources/sipcommands.yaml
+++ b/pyrainbird/resources/sipcommands.yaml
@@ -6,12 +6,14 @@ ControllerCommands:
     length: 1
   AvailableStationsRequest:
     command: '03'
-    parameter: 0
     response: '83'
     length: 2
+    page:
+      position: 2
+      length: 2
   CommandSupportRequest:
     command: '04'
-    commandToTest: '02'
+    parameter: '02'  #commandToTest: '02'
     response: '84'
     length: 2
   SerialNumberRequest:
@@ -223,8 +225,8 @@ ControllerResponses:
       length: 3
   RetrieveScheduleResponse:
     command: 'A0'
-    length: 18
-    # Requires a custom processor that can't be expressed in yaml
+    # Requires a custom processor that can't be expressed in yaml. This
+    # does not set a length for now to indicate it requires custom encoding.
     decoder: decode_schedule
   WaterBudgetResponse:
     command: 'B0'

--- a/tests/testdata/available_stations.yaml
+++ b/tests/testdata/available_stations.yaml
@@ -1,6 +1,16 @@
 data:
-  - 830F0010
+  - "0300"
+  - "83003F000000"
+  - "0315"
+  - "83FF00000000"
 decoded_data:
+  - type: AvailableStationsRequest
+    page: 0
   - type: AvailableStationsResponse
-    pageNumber: 15
-    setStations: 16
+    pageNumber: 0
+    setStations: 0x3F000000
+  - type: AvailableStationsRequest
+    page: 0x15
+  - type: AvailableStationsResponse
+    pageNumber: 255
+    setStations: 0

--- a/tests/testdata/model_and_version.yaml
+++ b/tests/testdata/model_and_version.yaml
@@ -1,7 +1,9 @@
 data:
+  - "02"
   - "820006090C"
   - "850000000000008963"
 decoded_data:
+  - type: ModelAndVersionRequest
   - type: ModelAndVersionResponse
     modelID: 6
     protocolRevisionMajor: 9

--- a/tests/testdata/settings.yaml
+++ b/tests/testdata/settings.yaml
@@ -4,7 +4,8 @@ data:
   - B0000064
   - B0010050
   - B0020050
-  - BB0000000000000000FF0000
+  # Not decoding current queue
+  # - BB0000000000000000FF0000
   - BF0000000000
   - CA012B483163
   - CC1228270417E700040001FFFF000000
@@ -26,7 +27,7 @@ decoded_data:
     programCode: 2
     seasonalAdjust: 80
   # Not currently parsed CurrentQueueResponse
-  - data: BB0000000000000000FF0000
+  # - data: BB0000000000000000FF0000
   - type: CurrentStationsActiveResponse
     activeStations: 0
     pageNumber: 0


### PR DESCRIPTION
Unify how requests and responses are encoded/decoded so the same libraries can be used on both. This is helpful to support mitm proxy plugins, but also to add variable length input fields like set date/time.

Many commands still need to be moved to the new yaml format for encoding.

Issue #57