### PR TITLE
Add support for encoding/decoding irrigation queue messages

### DIFF
--- a/pyrainbird/resources/sipcommands.yaml
+++ b/pyrainbird/resources/sipcommands.yaml
@@ -104,7 +104,13 @@ ControllerCommands:
     parameter: 0
     response: '01'
     length: 2
-  # CurrentQueueRequest: 3B
+  CurrentQueueRequest:
+    command: 3B
+    response: 'BB'
+    length: 2
+    page:
+      position: 2
+      length: 2
   CurrentRainSensorStateRequest:
     command: 3E
     response: BE
@@ -145,6 +151,15 @@ ControllerCommands:
     parameterThree: 0
     response: '01'
     length: 4
+    page:
+      position: 2
+      length: 2
+    zone:
+      position: 4
+      length: 2
+    minutes:
+      position: 6
+      length: 2
   CombinedControllerStateRequest:
     command: 4C
     response: CC
@@ -278,7 +293,9 @@ ControllerResponses:
     delaySetting:
       position: 2
       length: 4
-  # CurrentQueueResponse BB
+  CurrentQueueResponse:
+    command: BB
+    decoder: decode_queue
   CurrentRainSensorStateResponse:
     command: 'BE'
     length: 2

--- a/tests/testdata/current_queue.yaml
+++ b/tests/testdata/current_queue.yaml
@@ -1,0 +1,119 @@
+data:
+- 4B000102
+- 014B
+- 4B000202
+- 014B
+- 4B000302
+- 014B
+- 3B00
+- BB000401020000
+- 3B01
+- BB01000176000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+- 3B02
+- BB02000278000000000378000000000000000000000000000000000000000000000000000000000000000000000000000000
+- 3B01
+- BB0100016B000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+- 3B02
+- BB02000278000000000378000000000000000000000000000000000000000000000000000000000000000000000000000000
+- 3B01
+- BB01000161000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+- 3B02
+- BB02000278000000000378000000000000000000000000000000000000000000000000000000000000000000000000000000
+- 3B01
+- BB01000157000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+- 3B02
+- BB02000278000000000378000000000000000000000000000000000000000000000000000000000000000000000000000000
+decoded_data:
+- type: StackManuallyRunStationRequest
+  page: 0
+  zone: 1
+  minutes: 2
+- type: AcknowledgeResponse
+  commandEcho: 75
+- type: StackManuallyRunStationRequest
+  page: 0
+  zone: 2
+  minutes: 2
+- type: AcknowledgeResponse
+  commandEcho: 75
+- type: StackManuallyRunStationRequest
+  page: 0
+  zone: 3
+  minutes: 2
+- type: AcknowledgeResponse
+  commandEcho: 75
+- type: CurrentQueueRequest
+  page: 0
+- type: CurrentQueueResponse
+  program:
+    program: 4  # Manual
+    running: True
+    zonesRemaining: 2
+- type: CurrentQueueRequest
+  page: 1
+- type: CurrentQueueResponse
+  zones:
+    - zone: 1
+      program: 0
+      seconds: 118
+- type: CurrentQueueRequest
+  page: 2
+- type: CurrentQueueResponse
+  zones:
+    - zone: 2
+      program: 0
+      seconds: 120
+    - zone: 3
+      program: 0
+      seconds: 120
+- type: CurrentQueueRequest
+  page: 1
+- type: CurrentQueueResponse
+  zones:
+    - zone: 1
+      program: 0
+      seconds: 107
+- type: CurrentQueueRequest
+  page: 2
+- type: CurrentQueueResponse
+  zones:
+    - zone: 2
+      program: 0
+      seconds: 120
+    - zone: 3
+      program: 0
+      seconds: 120
+- type: CurrentQueueRequest
+  page: 1
+- type: CurrentQueueResponse
+  zones:
+    - zone: 1
+      program: 0
+      seconds: 97
+- type: CurrentQueueRequest
+  page: 2
+- type: CurrentQueueResponse
+  zones:
+    - zone: 2
+      program: 0
+      seconds: 120
+    - zone: 3
+      program: 0
+      seconds: 120
+- type: CurrentQueueRequest
+  page: 1
+- type: CurrentQueueResponse
+  zones:
+    - zone: 1
+      program: 0
+      seconds: 87
+- type: CurrentQueueRequest
+  page: 2
+- type: CurrentQueueResponse
+  zones:
+    - zone: 2
+      program: 0
+      seconds: 120
+    - zone: 3
+      program: 0
+      seconds: 120


### PR DESCRIPTION
Add support for encoding/decoding irrigation queue messages

Issue #40

Using test case examples from https://github.com/donavanbecker/homebridge-rainbird/issues/396 