### PR TITLE
Breaking change: Remove pageable APIs and cache static data

### DIFF
--- a/pyrainbird/__init__.py
+++ b/pyrainbird/__init__.py
@@ -4,7 +4,6 @@ import time
 from functools import reduce
 
 from pyrainbird.data import (
-    _DEFAULT_PAGE,
     AvailableStations,
     CommandSupport,
     ModelAndVersion,
@@ -15,6 +14,8 @@ from pyrainbird.resources import RAINBIRD_COMMANDS, RAINBIRD_COMMANDS_BY_ID
 
 from . import rainbird
 from .client import RainbirdClient
+
+_DEFAULT_PAGE = 0
 
 
 class RainbirdController:
@@ -47,14 +48,14 @@ class RainbirdController:
             "ModelAndVersion",
         )
 
-    def get_available_stations(self, page=_DEFAULT_PAGE):
+    def get_available_stations(self):
         mask = "%%0%dX" % RAINBIRD_COMMANDS_BY_ID["83"]["setStations"]["length"]
         return self._process_command(
             lambda resp: AvailableStations(
-                mask % resp["setStations"], page=resp["pageNumber"]
+                mask % resp["setStations"]
             ),
             "AvailableStations",
-            page,
+            _DEFAULT_PAGE,
         )
 
     def get_command_support(self, command):

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -9,15 +9,7 @@ from pydantic import BaseModel, Field, root_validator
 
 from .resources import RAINBIRD_MODELS
 
-_DEFAULT_PAGE = 0
 _MAX_ZONES = 32
-
-
-@dataclass
-class Pageable:
-    """Response object that supports paging."""
-
-    page: int = _DEFAULT_PAGE
 
 
 @dataclass
@@ -134,28 +126,18 @@ class States:
         return "states: %s" % ", ".join(result)
 
 
-class AvailableStations(Pageable):
-    def __init__(self, mask, page=_DEFAULT_PAGE):
-        super(AvailableStations, self).__init__(page)
+@dataclass
+class AvailableStations:
+
+    stations: States
+
+    def __init__(self, mask: str):
         self.stations = States(mask)
 
     @property
     def active_set(self):
         """Return the set of active zones."""
         return self.stations.active_set
-
-    def __hash__(self):
-        return hash((super(AvailableStations, self).__hash__(), self.stations))
-
-    def __eq__(self, o):
-        return (
-            super(AvailableStations, self).__eq__(o)
-            and isinstance(o, AvailableStations)
-            and self.stations == o.stations
-        )
-
-    def __ne__(self, o):
-        return not self.__eq__(o)
 
     def __str__(self):
         return "available stations: %X, %s" % (
@@ -164,29 +146,10 @@ class AvailableStations(Pageable):
         )
 
 
-class WaterBudget(object):
-    def __init__(self, program, adjust):
-        self.program = program
-        self.adjust = adjust
-
-    def __hash__(self):
-        return hash((self.program, self.adjust))
-
-    def __eq__(self, o):
-        return (
-            isinstance(o, WaterBudget)
-            and self.program == o.program
-            and self.adjust == o.adjust
-        )
-
-    def __ne__(self, o):
-        return not self.__eq__(o)
-
-    def __str__(self):
-        return "water budget: program: %d, adjust: %s" % (
-            self.program,
-            self.adjust,
-        )
+@dataclass
+class WaterBudget:
+    program: int
+    adjust: int
 
 
 class WifiParams(BaseModel):

--- a/pyrainbird/encryption.py
+++ b/pyrainbird/encryption.py
@@ -119,7 +119,7 @@ class PayloadCoder:
                 try:
                     value = ErrorCode(code)
                 except ValueError:
-                    value = UNKNOWN
+                    value = ErrorCode.UNKNOWN
                 msg.append(f"Code: {str(value)}({code})")
             if message := error.get("message"):
                 msg.append(f"Message: {message}")

--- a/pyrainbird/encryption.py
+++ b/pyrainbird/encryption.py
@@ -118,13 +118,11 @@ class PayloadCoder:
             if code := error.get("code"):
                 try:
                     value = ErrorCode(code)
-                except ValuError:
+                except ValueError:
                     value = UNKNOWN
                 msg.append(f"Code: {str(value)}({code})")
             if message := error.get("message"):
                 msg.append(f"Message: {message}")
             full_message = ", ".join(msg)
-            if code is not None and code == 0:
-                raise RainbirdCommandNotSupported(full_message)
             raise RainbirdApiException(", ".join(msg))
         return response["result"]

--- a/pyrainbird/exceptions.py
+++ b/pyrainbird/exceptions.py
@@ -5,9 +5,13 @@ class RainbirdApiException(Exception):
     """Exception from rainbird api."""
 
 
-class RainbirdAuthException(Exception):
+class RainbirdDeviceBusyException(RainbirdApiException):
+    """Device is busy processing another request."""
+
+
+class RainbirdAuthException(RainbirdApiException):
     """Authentication exception from rainbird API."""
 
 
-class RainbirdCodingException(Exception):
+class RainbirdCodingException(RainbirdApiException):
     """Error while encoding or decoding objects."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -13,7 +13,7 @@ from pyrainbird import ModelAndVersion, WaterBudget, rainbird
 from pyrainbird.async_client import AsyncRainbirdClient, AsyncRainbirdController
 from pyrainbird.data import SoilType
 from pyrainbird.encryption import encrypt
-from pyrainbird.exceptions import RainbirdApiException, RainbirdAuthException
+from pyrainbird.exceptions import RainbirdApiException, RainbirdAuthException, RainbirdDeviceBusyException
 from pyrainbird.resources import RAINBIRD_COMMANDS_BY_ID
 
 from .conftest import LENGTH, PASSWORD, REQUEST, RESPONSE, RESULT_DATA, ResponseResult
@@ -39,6 +39,18 @@ async def test_request_failure(
     response(aiohttp.web.Response(status=500))
     client = await rainbird_client()
     with pytest.raises(RainbirdApiException):
+        await client.request(REQUEST, LENGTH)
+
+
+async def test_device_busy_failure(
+    rainbird_client: Callable[[], Awaitable[AsyncRainbirdClient]],
+    response: ResponseResult,
+) -> None:
+    """Test a basic request failure handling."""
+
+    response(aiohttp.web.Response(status=503))
+    client = await rainbird_client()
+    with pytest.raises(RainbirdDeviceBusyException):
         await client.request(REQUEST, LENGTH)
 
 
@@ -115,6 +127,10 @@ async def test_get_serial_number(
 ) -> None:
     controller = await rainbird_controller()
     api_response("85", serialNumber=0x12635436566)
+    assert await controller.get_serial_number() == 0x12635436566
+    # Result is cached
+    assert await controller.get_serial_number() == 0x12635436566
+    assert await controller.get_serial_number() == 0x12635436566
     assert await controller.get_serial_number() == 0x12635436566
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -648,6 +648,22 @@ async def test_error_response(
         await controller.test_rpc_support("invalid")
 
 
+async def test_unknown_error_response(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    encrypt_response: ResponseResult,
+) -> None:
+    """Test checking for an RPC support."""
+    controller = await rainbird_controller()
+    payload = {
+        "jsonrpc": "2.0",
+        "error": {"code": 9090, "message": "Some error"},
+        "id": "null",
+    }
+    encrypt_response(payload)
+    with pytest.raises(RainbirdApiException, match=r"Some error"):
+        await controller.test_rpc_support("invalid")
+
+
 async def test_unrecognized_response(
     rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
     encrypt_response: ResponseResult,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,10 +29,10 @@ class TestCase(unittest.TestCase):
 
     @responses.activate
     def test_get_available_stations(self):
-        mock_response("83", pageNumber=1, setStations=0x7F000000)
+        mock_response("83", pageNumber=0, setStations=0x7F000000)
         rainbird = RainbirdController(MOCKED_RAINBIRD_URL, MOCKED_PASSWORD)
         self.assertEqual(
-            AvailableStations("7f000000", 1), rainbird.get_available_stations()
+            AvailableStations("7f000000"), rainbird.get_available_stations()
         )
 
     @responses.activate


### PR DESCRIPTION
Remove the `Pageable` interface that is currently used for commands with no interesting second pages and are never used by the device in practice. The `page` argument is removed from `get_available_stations` and  `get_zone_states` commands 

Adds a cache for commands that are static data about the device, for use in future more complex calls that care about the type of the device.

Improves error handling for common error cases. Issue #91