### PR TITLE
Add an API for a timeline of upcoming irrigation events

### DIFF
--- a/pyrainbird/const.py
+++ b/pyrainbird/const.py
@@ -1,0 +1,15 @@
+"""Constants for rainbird."""
+
+from enum import IntEnum
+
+
+class DayOfWeek(IntEnum):
+    """Day of the week."""
+
+    SUNDAY = 0
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6

--- a/pyrainbird/timeline.py
+++ b/pyrainbird/timeline.py
@@ -1,0 +1,187 @@
+"""A timeline is a set of events on a calendar.
+
+This timeline is used to iterate over program runtime events, manging
+the logic for interpreting recurring events for the Rain Bird controller.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Callable, Iterable, Iterator
+from typing import Union
+
+from dateutil import rrule
+
+from .const import DayOfWeek
+from .timespan import Timespan
+
+__all__ = ["ProgramTimeline"]
+
+RRULE_WEEKDAY = {
+    DayOfWeek.MONDAY: rrule.MO,
+    DayOfWeek.TUESDAY: rrule.TU,
+    DayOfWeek.WEDNESDAY: rrule.WE,
+    DayOfWeek.THURSDAY: rrule.TH,
+    DayOfWeek.FRIDAY: rrule.FR,
+    DayOfWeek.SATURDAY: rrule.SA,
+    DayOfWeek.SUNDAY: rrule.SU,
+}
+
+
+class ProgramTimeline:
+    """A timeline of events in an irrigation program."""
+
+    def __init__(self, iterable: Iterable[Timespan]) -> None:
+        self._iterable = iterable
+
+    def __iter__(self) -> Iterator[Timespan]:
+        """Return an iterator as a traversal over events in chronological order."""
+        for item in iter(self._iterable):
+            yield item.item
+
+    def overlapping(
+        self,
+        start: datetime.datetime,
+        end: datetime.datetime,
+    ) -> Iterator[Timespan]:
+        """Return an iterator containing events active during the timespan.
+
+        The end date is exclusive.
+        """
+        timespan = Timespan.of(start, end)
+        for item in self._iterable:
+            if item.intersects(timespan):
+                yield item
+            elif item > timespan:
+                break
+
+
+ItemAdapter = Callable[[Union[datetime.datetime]], Timespan]
+"""An adapter for an object in a sorted container (iterator).
+
+The adapter is invoked with the date/time of the current instance and
+the callback returns an object at that time (e.g. event with updated time)
+"""
+
+
+class RecurIterable(Iterable[Timespan]):
+    """A series of events from a recurring event.
+
+    The inputs are a callback that creates objects at a specific date/time, and an iterable
+    of all the relevant date/times (typically a dateutil.rrule or dateutil.rruleset).
+    """
+
+    def __init__(
+        self,
+        item_cb: ItemAdapter[Timespan],
+        recur: Iterable[datetime.datetime],
+    ) -> None:
+        """Initialize timeline."""
+        self._item_cb = item_cb
+        self._recur = recur
+
+    def __iter__(self) -> Iterator[Timespan]:
+        """Return an iterator as a traversal over events in chronological order."""
+        for dtvalue in self._recur:
+            yield self._item_cb(dtvalue)
+
+
+def custom_recurrence(
+    days_of_week: set[DayOfWeek],
+    times_of_day: list[datetime.time],
+    duration: datetime.timedelta,
+    synchro: int,
+) -> Iterable[datetime.datetime]:
+    """Create a timeline for a CUSTOM program."""
+    # Each 'times_of_day' will be its own RRULE.
+    # Start counting the dates from 'synchro'
+    first_day = datetime.datetime.now() + datetime.timedelta(days=synchro)
+    dtstarts = [
+        first_day.replace(hour=time_of_day.hour, minute=time_of_day.minute, second=0)
+        for time_of_day in times_of_day
+    ]
+    # Create a RRULE that is FREQ=WEEKLY with every `days_of_week` as the
+    # instances within the week.
+    byweekday = [RRULE_WEEKDAY[day_of_week] for day_of_week in days_of_week]
+    ruleset = rrule.rruleset()
+    for dtstart in dtstarts:
+        ruleset.rrule(
+            rrule.rrule(
+                freq=rrule.WEEKLY,
+                byweekday=byweekday,
+                dtstart=dtstart,
+                cache=True,
+            )
+        )
+        # Exclude the first instance
+        ruleset.exdate(dtstart)
+
+    return RecurIterable(
+        lambda dtstart: Timespan.of(dtstart, dtstart + duration),
+        ruleset,
+    )
+
+
+def cyclic_recurrence(
+    interval: int,
+    times_of_day: list[datetime.time],
+    duration: datetime.timedelta,
+    synchro: int,
+) -> Iterable[datetime.datetime]:
+    """Create a timeline for a CUSTOM program."""
+    # Each 'times_of_day' will be its own RRULE.
+    first_day = datetime.datetime.now() + datetime.timedelta(days=synchro)
+    dtstarts = [
+        first_day.replace(hour=time_of_day.hour, minute=time_of_day.minute, second=0)
+        for time_of_day in times_of_day
+    ]
+    # Create a RRULE that is FREQ=DAILY with an `interval` between dates
+    ruleset = rrule.rruleset()
+    for dtstart in dtstarts:
+        ruleset.rrule(
+            rrule.rrule(
+                freq=rrule.DAILY,
+                interval=interval,
+                dtstart=dtstart,
+                cache=True,
+            )
+        )
+        ruleset.exdate(dtstart)
+
+    return RecurIterable(
+        lambda dtstart: Timespan.of(dtstart, dtstart + duration),
+        ruleset,
+    )
+
+
+def odd_even_recurrence(
+    odd_days: bool,
+    times_of_day: list[datetime.time],
+    duration: datetime.timedelta,
+    synchro: int,
+) -> Iterable[datetime.datetime]:
+    """Create a timeline for a CUSTOM program."""
+    # Each 'times_of_day' will be its own RRULE.
+    first_day = datetime.datetime.now() + datetime.timedelta(days=synchro)
+    dtstarts = [
+        first_day.replace(hour=time_of_day.hour, minute=time_of_day.minute, second=0)
+        for time_of_day in times_of_day
+    ]
+    # Create a RRULE that is FREQ=MONTHLY with all odd/even days of the month
+    bymonthday = [i for i in range(1, 32) if ((i % 2) == 1) == odd_days]
+    ruleset = rrule.rruleset()
+    for dtstart in dtstarts:
+        ruleset.rrule(
+            rrule.rrule(
+                freq=rrule.MONTHLY,
+                bymonthday=bymonthday,
+                dtstart=dtstart,
+                cache=True,
+            )
+        )
+        ruleset.exdate(dtstart)
+
+    return RecurIterable(
+        lambda dtstart: Timespan.of(dtstart, dtstart + duration),
+        ruleset,
+    )

--- a/pyrainbird/timespan.py
+++ b/pyrainbird/timespan.py
@@ -1,0 +1,100 @@
+"""A timeline is a set of events on a calendar.
+
+This timeline is used to iterate over program runtime events, manging
+the logic for interpreting recurring events for the Rain Bird controller.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = []
+
+
+MIDNIGHT = datetime.time()
+
+
+def local_timezone() -> datetime.tzinfo:
+    """Get the local timezone to use when converting date to datetime."""
+    if local_tz := datetime.datetime.now().astimezone().tzinfo:
+        return local_tz
+    return datetime.timezone.utc
+
+
+def normalize_datetime(
+    value: datetime.datetime, tzinfo: datetime.tzinfo | None = None
+) -> datetime.datetime:
+    """Convert date or datetime to a value that can be used for comparison."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=tzinfo if tzinfo else local_timezone())
+    return value
+
+
+@dataclass
+class Timespan:
+    """An unambiguous definition of a start and end time.
+
+    A timespan is not ambiguous in that it can never be a "floating" time range
+    and instead is always aligned to some kind of timezone or utc.
+    """
+
+    start: datetime.datetime
+    """Return the timespan start as a datetime."""
+
+    end: datetime.datetime
+    """Return the timespan end as a datetime."""
+
+    def __post_init__(self) -> None:
+        if not self.start.tzinfo:
+            raise ValueError(f"Start time did not have a timezone: {self.start}")
+        self._tzinfo = self.start.tzinfo
+
+    @classmethod
+    def of(  # pylint: disable=invalid-name]
+        cls,
+        start: datetime.datetime,
+        end: datetime.datetime,
+    ) -> "Timespan":
+        """Create a Timestapn for the specified date range."""
+        return Timespan(normalize_datetime(start), normalize_datetime(end))
+
+    @property
+    def tzinfo(self) -> datetime.tzinfo:
+        """Return the timespan timezone."""
+        return self._tzinfo
+
+    @property
+    def duration(self) -> datetime.timedelta:
+        """Return the timespan duration."""
+        return self.end - self.start
+
+    def intersects(self, other: "Timespan") -> bool:
+        """Return True if this timespan overlaps with the other event."""
+        return (
+            other.start <= self.start < other.end
+            or other.start < self.end <= other.end
+            or self.start <= other.start < self.end
+            or self.start < other.end <= self.end
+        )
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return (self.start, self.end) < (other.start, other.end)
+
+    def __gt__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return (self.start, self.end) > (other.start, other.end)
+
+    def __le__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return (self.start, self.end) <= (other.start, other.end)
+
+    def __ge__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return (self.start, self.end) >= (other.start, other.end)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,6 +13,7 @@ pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 pytest-golden==0.2.2
 pytest-mock==3.10.0
+python-dateutil==2.8.2
 requests==2.28.2
 requests-mock==1.10.0
 responses==0.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,8 @@ install_requires =
   pycryptodome>=3.16.0
   requests>=2.22.0
   PyYAML>=5.4
-  pydantic
+  pydantic>=1.10.4
+  python-dateutil>=2.8.2
 install_package_data = True
 package_dir =
   = .


### PR DESCRIPTION
Add an API for a timeline of upcoming irrigation events.

Adds different implementations for `CYCLIC`, `CUSTOM`, `ODD`, and `EVEN` rules using `dateutil.rrule`.

The APIs are borrowed from the timeline/timespan used by `ical` and `gcal_sync`. These may change before release to explicitly reuse.

Issue #92