### PR TITLE
Improve schedule support with raindelay and backwards cycles

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -375,6 +375,7 @@ class AsyncRainbirdController:
         _LOGGER.debug("Sending schedule commands: %s", commands)
         # Run command serially to avoid overwhelming the controller
         schedule_data = {
+            "controllerInfo": {},
             "programInfo": [],
             "programStartInfo": [],
             "durations": [],
@@ -394,6 +395,8 @@ class AsyncRainbirdController:
                             ) not in stations.stations.active_set:
                                 continue
                             schedule_data[key].append(entry)
+                    elif key == "controllerInfo":
+                        schedule_data[key].update(value)
                     else:
                         schedule_data[key].append(value)
         return Schedule.parse_obj(schedule_data)

--- a/pyrainbird/timeline.py
+++ b/pyrainbird/timeline.py
@@ -79,16 +79,15 @@ def create_recurrence(
             + time_shift
         )
 
-    # These weekday or day of month refinemens only used in specific scenarios
+    # These weekday or day of month refinemens ared used in specific scenarios
     byweekday = [RRULE_WEEKDAY[day_of_week] for day_of_week in days_of_week]
     odd_days = frequency == ProgramFrequency.ODD
     bymonthday = [i for i in range(1, 32) if ((i % 2) == 1) == odd_days]
 
     ruleset = rrule.rruleset()
     for dtstart in dtstarts:
-        # Rain delay just excludes the next days from the schedule
+        # Rain delay excludes upcoming days from the schedule
         for i in range(0, delay_days):
-            _LOGGER.debug("d=%s", dtstart + datetime.timedelta(days=i))
             ruleset.exdate(dtstart + datetime.timedelta(days=i))
 
         # Start the schedule from the previous week/cycle


### PR DESCRIPTION
Add a rain delay, which excludes upcoming days from the schedule. Go backwards one week or one cycle when starting the schedule. Fix various parsing errors to include the rain delay in the schedule.
Issue #92