### PR TITLE
Perform jittered retries for ESP-ME* devices on 503

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -15,7 +15,7 @@ import datetime
 import logging
 from collections.abc import Callable
 from http import HTTPStatus
-from typing import Any, TypeVar
+from typing import Any, TypeVar, Union
 
 import aiohttp
 from aiohttp.client_exceptions import ClientError, ClientResponseError
@@ -89,7 +89,7 @@ class AsyncRainbirdClient:
         self,
         websession: aiohttp.ClientSession,
         host: str,
-        password: str | None,
+        password: Union[str, None],
     ) -> None:
         self._websession = websession
         self._host = host

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -109,7 +109,7 @@ class AsyncRainbirdClient:
         )
 
     async def request(
-        self, method: str, params: dict[str, Any] | None = None
+        self, method: str, params: Union[dict[str, Any], None] = None
     ) -> dict[str, Any]:
         """Send a request for any command."""
         payload = self._coder.encode_command(method, params or {})

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -38,7 +38,6 @@ class CommandSupport:
     support: int
     """Return if the command is supported."""
 
-
     echo: int
     """Return the input command."""
 
@@ -67,6 +66,9 @@ class ModelInfo:
 
     max_run_times: int
     """The maximum number of run times supported by the device."""
+
+    retries: bool = False
+    """If device busy errors should be retried"""
 
 
 @dataclass

--- a/pyrainbird/resources/models.yaml
+++ b/pyrainbird/resources/models.yaml
@@ -12,6 +12,7 @@
   supports_water_budget: true
   max_programs: 4
   max_run_times: 6
+  retries: true
 
 - device_id: "0006"
   code: ST8X_WF
@@ -40,6 +41,7 @@
   supports_water_budget: true
   max_programs: 4
   max_run_times: 6
+  retries: true
 
 - device_id: "0010"
   code: MOCK_ESP_ME2
@@ -47,6 +49,7 @@
   supports_water_budget: true
   max_programs: 4
   max_run_times: 6
+  retries: true
 
 - device_id: "000a"
   code: ESP_TM2v2
@@ -75,6 +78,7 @@
   supports_water_budget: true
   max_programs: 4
   max_run_times: 6
+  retries: true
 
 - device_id: "0103"
   code: ESP_RZXe2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 -e .
 aiohttp==3.8.4
+aiohttp_retry==2.8.3
 freezegun==1.2.2
 mitmproxy==9.0.1
 parameterized==0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,8 @@ install_requires =
   pydantic>=1.10.4
   python-dateutil>=2.8.2
   ical>=4.2.9
+  aiohttp_retry>=2.8.3
+
 install_package_data = True
 package_dir =
   = .


### PR DESCRIPTION
Devices respond 503 when handling another request. ESP-ME* devices seem to do this more often than other devices, so allow retries in those cases (even though requests are sent serially)