### PR TITLE
Fix device code for ARC8, RC2, TBOS-BT and handle unknown devices

### DIFF
--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -100,7 +100,9 @@ class ModelAndVersion:
     @property
     def model_info(self) -> ModelInfo:
         """Return details about a device model capabilities."""
-        return ModelInfo(**RAINBIRD_MODELS["%04x" % self.model])
+        key = f"{self.model:04x}"
+        data = RAINBIRD_MODELS.get(key, RAINBIRD_MODELS["UNKNOWN"])
+        return ModelInfo(**data)
 
     def __str__(self):
         return "model: %04X (%s), version: %d.%d" % (

--- a/pyrainbird/resources/models.yaml
+++ b/pyrainbird/resources/models.yaml
@@ -52,7 +52,6 @@
   max_run_times: 6
   retries: true
 
-
 - device_id: "000a"
   code: ESP_TM2v2
   name: ESP-TM2

--- a/pyrainbird/resources/models.yaml
+++ b/pyrainbird/resources/models.yaml
@@ -52,6 +52,7 @@
   max_run_times: 6
   retries: true
 
+
 - device_id: "000a"
   code: ESP_TM2v2
   name: ESP-TM2
@@ -67,6 +68,13 @@
   max_run_times: 4
 
 - device_id: "0099"
+  code: TBOS_BT
+  name: TBOS-BT
+  supports_water_budget: true
+  max_programs: 3
+  max_run_times: 8
+
+- device_id: "0100"
   code: TBOS_BT
   name: TBOS-BT
   supports_water_budget: true
@@ -89,8 +97,23 @@
   max_run_times: 6
 
 - device_id: "0812"
+  code: RC2
+  name: RC2
+  supports_water_budget: true
+  max_programs: 3
+  max_run_times: 4
+
+- device_id: "0813"
   code: ARC8
   name: ARC8
   supports_water_budget: true
   max_programs: 3
   max_run_times: 4
+
+- device_id: "UNKNOWN"
+  code: UNKNOWN
+  name: Unknown
+  supports_water_budget: false
+  max_programs: 0
+  max_run_times: 0
+  retries: false

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,8 +1,10 @@
 import unittest
+from typing import Any
 
+import pytest
 from parameterized import parameterized
 
-from pyrainbird.data import States
+from pyrainbird.data import States, ModelAndVersion
 
 
 def encode_name_func(testcase_func, param_num, param):
@@ -54,3 +56,26 @@ class TestSequence(unittest.TestCase):
             active = i in states.active_set
             assert active == bit
             i = i + 1
+
+@pytest.mark.parametrize(
+    ("response", "expected_name"),
+    [
+        (
+            {'modelID': 2067, 'protocolRevisionMajor': 2, 'protocolRevisionMinor': 12},
+            "ARC8"
+        ),
+        (
+            {'modelID': 9999, 'protocolRevisionMajor': 2, 'protocolRevisionMinor': 12},
+            "Unknown"
+        ),
+    ],
+)
+def test_model_info(response: dict[str, Any], expected_name: str) -> None:
+    """Test parsing of ModelInfo responses."""
+    mv = ModelAndVersion(
+        response["modelID"],
+        response["protocolRevisionMajor"],
+        response["protocolRevisionMinor"],
+    )
+    assert mv.model_name == expected_name
+    assert mv.model_info.name == expected_name


### PR DESCRIPTION
- Fix the device code for RC2 which was labeld as ARC8
- Fix the device code for ARC8
- Add additional device code for TBOS-BT
- Handle unknown device codes