### PR TITLE
Improve exceptions making them more user friendly

### DIFF
--- a/pyrainbird/encryption.py
+++ b/pyrainbird/encryption.py
@@ -13,6 +13,7 @@ from Crypto.Hash import SHA256
 
 from .exceptions import RainbirdApiException
 
+
 BLOCK_SIZE = 16
 INTERRUPT = "\x00"
 PAD = "\x10"
@@ -124,5 +125,6 @@ class PayloadCoder:
             if message := error.get("message"):
                 msg.append(f"Message: {message}")
             ", ".join(msg)
-            raise RainbirdApiException(", ".join(msg))
+            self._logger.debug("Error from controller: %s", msg)
+            raise RainbirdApiException(f"Rain Bird responded with an error: {message}")
         return response["result"]

--- a/pyrainbird/exceptions.py
+++ b/pyrainbird/exceptions.py
@@ -13,5 +13,5 @@ class RainbirdAuthException(RainbirdApiException):
     """Authentication exception from rainbird API."""
 
 
-class RainbirdCodingException(RainbirdApiException):
-    """Error while encoding or decoding objects."""
+class RainbirdCodingException(Exception):
+    """Error while encoding or decoding objects indicating a bug."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -768,7 +768,9 @@ async def test_unrecognized_response(
         "id": 0,
     }
     encrypt_response(payload)
-    with pytest.raises(RainbirdApiException, match=r"wrong response"):
+    with pytest.raises(
+        RainbirdApiException, match=r"Unexpected response from Rain Bird device"
+    ):
         await controller.test_command_support("00")
 
 


### PR DESCRIPTION
Update the string messages used in exceptions to make them more end user friendly, while moving internal details such as error codes and more detailed strings into either error messages or debug messages depending on how likely they are to occur.

This contains a breaking change, moving the coding exception (which is thrown for coding bugs) to longer be part of the api exception hierarchy.