### PR TITLE
Fix bug in decoding RetrieveScheduleResponse

### DIFF
--- a/pyrainbird/rainbird.py
+++ b/pyrainbird/rainbird.py
@@ -41,9 +41,9 @@ def decode_schedule(data: str, cmd_template: dict[str, Any]) -> dict[str, Any]:
         # Delay, Snooze, Rainsensor
         return {
             "controllerInfo": {
-                "stationDelay": int(rest[0:4]),
-                "rainDelay": int(rest[4:6]),
-                "rainSensor": int(rest[6:8]),
+                "stationDelay": int(rest[0:4], 16),
+                "rainDelay": int(rest[4:6], 16),
+                "rainSensor": int(rest[6:8], 16),
             }
         }
 

--- a/tests/testdata/rain_delay.yaml
+++ b/tests/testdata/rain_delay.yaml
@@ -1,5 +1,8 @@
 data:
   - "B60003"
+  - "B6000E"
 decoded_data:
   - type: RainDelaySettingResponse
     delaySetting: 3
+  - type: RainDelaySettingResponse
+    delaySetting: 14

--- a/tests/testdata/schedule_rain_delay.yaml
+++ b/tests/testdata/schedule_rain_delay.yaml
@@ -1,0 +1,14 @@
+data:
+  - A0000000000400
+  - A0000000000E00
+decoded_data:
+  - type: RetrieveScheduleResponse
+    controllerInfo:
+      stationDelay: 0
+      rainSensor: 0
+      rainDelay: 4
+  - type: RetrieveScheduleResponse
+    controllerInfo:
+      stationDelay: 0
+      rainSensor: 0
+      rainDelay: 14


### PR DESCRIPTION
Fixes a bug decoding an integer in the wrong base. Currently able to reproduce when using a rain delay above 10:

```
Unexpected error fetching x.x.x.x Schedule data: invalid literal for int() with base 10: '0E'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 313, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/rainbird/coordinator.py", line 150, in _async_update_data
    return await self._controller.get_schedule()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pyrainbird/async_client.py", line 428, in get_schedule
    result = await self._process_command(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pyrainbird/async_client.py", line 489, in _process_command
    decoded = rainbird.decode(decrypted_data)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pyrainbird/rainbird.py", line 187, in decode
    return {TYPE: cmd_template[TYPE], **decoder(data, cmd_template)}
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pyrainbird/rainbird.py", line 45, in decode_schedule
    "rainDelay": int(rest[4:6]),
                 ^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '0E'
```