### PR TITLE
Remove unnecessary event_loop test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,6 @@ def mock_app() -> aiohttp.web.Application:
 
 @pytest.fixture(name="test_client")
 def cli_cb(
-    event_loop: asyncio.AbstractEventLoop,
     app: aiohttp.web.Application,
     aiohttp_client: Callable[[aiohttp.web.Application], Awaitable[TestClient]],
 ) -> Callable[[], Awaitable[TestClient]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Test fixtures for pyrainbird."""
 
-import asyncio
 import json
 from collections.abc import Awaitable, Callable
 from typing import cast


### PR DESCRIPTION
This cannot be used with the next version of pytest-asyncio.

https://github.com/allenporter/pyrainbird/pull/483