### PR TITLE
Revert all recent changes related to schedule loading

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -486,6 +486,7 @@ class AsyncRainbirdController:
         model = await self.get_model_and_version()
         max_programs = model.model_info.max_programs
         stations = await self.get_available_stations()
+        max_stations = min(stations.stations.count, 22)
 
         commands = ["00"]
         # Program details
@@ -495,19 +496,9 @@ class AsyncRainbirdController:
         for program in range(0, max_programs):
             commands.append("%04x" % (0x60 | program))
         # Run times per zone
-        if max_programs > 0:
-            # Modular/Program-based architecture (ESP-Me, ESP-TM2, RC2, etc)
-            # Fetch zone-runtime pages (0x80=zones 1-2, 0x81=3-4, etc).
-            # The app uses a fixed page count: 11 for 4-program models (22 zones max)
-            # and 6 for 3-program models (12 zones max).
-            page_limit = 11 if max_programs >= 4 else 6
-            for zone_page in range(0, page_limit):
-                commands.append("%04x" % (0x80 | zone_page))
-        else:
-            # Non-modular architecture (ESP-RZXe, ST8x, etc) fetches by zone directly.
-            for station_num in sorted(stations.stations.active_set):
-                commands.append("%04x" % station_num)
-
+        _LOGGER.debug("Loading schedule for %d zones", max_stations)
+        for zone_page in range(0, int(round(max_stations / 2, 0))):
+            commands.append("%04x" % (0x80 | zone_page))
         _LOGGER.debug("Sending schedule commands: %s", commands)
         # Run command serially to avoid overwhelming the controller
         schedule_data: dict[str, Any] = {

--- a/pyrainbird/rainbird.py
+++ b/pyrainbird/rainbird.py
@@ -97,19 +97,6 @@ def decode_schedule(data: str, cmd_template: dict[str, Any]) -> dict[str, Any]:
             ],
         }
 
-    if subcommand > 0:
-        # Single-zone based durations (e.g. ESP-RZXe)
-        rest = bytes(data[6:], "utf-8")
-        durations = list(int(rest[i : i + 4], 16) for i in range(0, len(rest), 4))
-        return {
-            "durations": [
-                {
-                    "zone": subcommand - 1,
-                    "durations": durations,
-                }
-            ]
-        }
-
     return {"data": data}
 
 

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1574,7 +1574,7 @@ async def test_get_schedule_esp_me_8_zones(
     # Zone runtimes for 11 pages (0x80 to 0x8A)
     # Page data format: A0 <page> <zone1_4_programs> <zone2_4_programs>
     # 4 programs * 4 chars = 16 chars per zone.
-    # We provide data for all 11 pages as defined by the ESP-Me model family.
+    # stations.count = 32 (8 hex chars * 4), min(32, 22) / 2 = 11 pages.
     responses.extend(
         [
             "A00080" + "000A000000000000" + "0005000000000000",  # Z1:P1=10, Z2:P1=5
@@ -1604,36 +1604,3 @@ async def test_get_schedule_esp_me_8_zones(
     assert durations[3] == datetime.timedelta(minutes=20)
     assert durations[7] == datetime.timedelta(minutes=15)
     assert durations[8] == datetime.timedelta(minutes=10)
-
-
-async def test_get_schedule_non_program_based(
-    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
-    api_response: Callable[..., Awaitable[None]],
-    sip_data_responses: Callable[[list[str]], None],
-    app: aiohttp.web.Application,
-) -> None:
-    """Test get_schedule for a non-program based device (ESP-RZXe)."""
-    controller = await rainbird_controller()
-
-    # ESP_RZXe: max_programs=0
-    api_response("82", modelID=0x03, protocolRevisionMajor=1, protocolRevisionMinor=3)
-    # Active zones: 1, 3, 5 (mask 0x15 = 00010101)
-    api_response("83", pageNumber=0, setStations="15000000")
-
-    # Responses: 1 (0x00) + 3 (zone commands: 0x01, 0x03, 0x05) = 4
-    # Note: 0x00 might not be needed but the code adds it.
-    responses = [
-        "A0000000000000",  # state
-        "A00001000A",  # Z1: 10m
-        "A000030014",  # Z3: 20m
-        "A00005001E",  # Z5: 30m
-    ]
-    sip_data_responses(responses)
-
-    schedule = await controller.get_schedule()
-
-    # Requests: 82, 83 + 4 commands = 6
-    assert len(app["request"]) == 6
-
-    # Let's check the result
-    assert len(schedule.programs) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -488,7 +488,7 @@ wheels = [
 
 [[package]]
 name = "pyrainbird"
-version = "6.0.5"
+version = "6.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp-retry" },


### PR DESCRIPTION
The previous changes attempted to fix support for some devices, but were not successful and caused extra unnecessary errors. WIll revert then try again in the future.