### PR TITLE
feat: Define base RainbirdController capability interfaces

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -74,11 +74,22 @@ from .resources import LENGTH, RAINBIRD_COMMANDS, RESPONSE
 
 
 class ControllerFeature(enum.StrEnum):
+    """Capabilities and features supported by a Rain Bird controller."""
+
     RAIN_DELAY = "rain_delay"
+    """Controller supports setting a rain delay duration."""
+
     SEASONAL_ADJUST = "seasonal_adjust"
+    """Controller supports seasonal adjust (water budget) percentage configuration."""
+
     FORECAST_DELAY = "forecast_delay"
+    """Controller supports automatic rain delays based on weather forecasts."""
+
     ZONE_IRRIGATION = "zone_irrigation"
+    """Controller supports starting and stopping individual zones manually."""
+
     CALENDAR_SCHEDULE = "calendar_schedule"
+    """Controller supports querying or setting the irrigation schedules."""
 
 
 class RainbirdController:

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -16,6 +16,7 @@ and querying the device.
 """
 
 import datetime
+import enum
 import logging
 import math
 import ssl
@@ -63,10 +64,80 @@ from .exceptions import (
 )
 from .resources import LENGTH, RAINBIRD_COMMANDS, RESPONSE
 
+
+class ControllerFeature(enum.StrEnum):
+    RAIN_DELAY = "rain_delay"
+    SEASONAL_ADJUST = "seasonal_adjust"
+    FORECAST_DELAY = "forecast_delay"
+    ZONE_IRRIGATION = "zone_irrigation"
+    CALENDAR_SCHEDULE = "calendar_schedule"
+
+
+class RainbirdController:
+    """Abstract base class representing a Rain Bird controller's capabilities."""
+
+    @property
+    def supported_features(self) -> set[ControllerFeature]:
+        """Return the features supported by this specific controller."""
+        raise NotImplementedError()
+
+    @property
+    def max_zones(self) -> int:
+        """Return the maximum number of stations supported."""
+        raise NotImplementedError()
+
+    @property
+    def max_programs(self) -> int:
+        """Return the maximum number of programs supported."""
+        raise NotImplementedError()
+
+    async def irrigate_zone(self, zone: int, minutes: int) -> None:
+        """Turn on irrigation for a single zone."""
+        raise NotImplementedError()
+
+    async def stop_irrigation(self) -> None:
+        """Turn off all active irrigation zones."""
+        raise NotImplementedError()
+
+    async def get_zone_states(self) -> States:
+        """Return which zones are currently active."""
+        raise NotImplementedError()
+
+    async def get_rain_sensor_state(self) -> bool:
+        """Return True if the rain sensor is active."""
+        raise NotImplementedError()
+
+    async def get_rain_delay(self) -> int:
+        """Return the remaining rain delay in days."""
+        raise NotImplementedError()
+
+    async def set_rain_delay(self, days: int) -> None:
+        """Set or clear a rain delay."""
+        raise NotImplementedError()
+
+    async def get_schedule(self) -> Schedule:
+        """Return the controller's irrigation schedule."""
+        raise NotImplementedError()
+
+
+class RainbirdTokenProvider:
+    """Interface for managing OAuth JWT authentication tokens."""
+
+    async def async_get_token(self, force_refresh: bool = False) -> str:
+        """Return a valid Bearer token.
+
+        If `force_refresh` is True, bypasses local caches to request a fresh token.
+        """
+        raise NotImplementedError()
+
+
 __all__ = [
     "CreateController",
     "create_controller",
     "AsyncRainbirdController",
+    "ControllerFeature",
+    "RainbirdController",
+    "RainbirdTokenProvider",
 ]
 
 _LOGGER = logging.getLogger(__name__)

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -7,6 +7,14 @@ password of the Rain Bird controller and performs local HTTP/HTTPS discovery.
 `CreateController` is a legacy factory that does not perform discovery and may
 not work with HTTPS-only controllers.
 
+.. note::
+   **WIP Migration to Capabilities Abstraction:**
+   The library is transitioning to a capability-based interface where callers query
+   controller features using `ControllerFeature` enums rather than concrete subclass types.
+   New implementations extend `RainbirdController` (e.g., concrete local HTTPS/JSON-RPC and
+   cloud REST clients), and utilize `RainbirdTokenProvider` for OAuth/OIDC credential lifetimes.
+   Legacy factory functions and `AsyncRainbirdController` remain supported for compatibility.
+
 Most API calls are fairly low level with thin response wrappers that are data classes,
 though some static data about the device may have the underlying calls cached.
 


### PR DESCRIPTION
This PR defines the core capability interfaces and ControllerFeature enums as outlined in CLIENT_DESIGN.md.

It introduces:
- `ControllerFeature` StrEnum (`RAIN_DELAY`, `SEASONAL_ADJUST`, `FORECAST_DELAY`, `ZONE_IRRIGATION`, `CALENDAR_SCHEDULE`)
- `RainbirdController` abstract base class for capability-based client delegation
- `RainbirdTokenProvider` abstract base class for OAuth/OIDC credentials management

Closes #566