### PR TITLE
feat: Implement local controller capability properties on AsyncRainbirdController

### DIFF
--- a/docs/CLIENT_DESIGN.md
+++ b/docs/CLIENT_DESIGN.md
@@ -130,7 +130,7 @@ Depending on how the user connects their device, the home automation client runs
 2. **Device Detection:**
    - **Port 80 Open:** The device is running legacy HTTP firmware.
      - *Client Action:* Prompt the user for the local device password.
-     - *Instantiation:* Call `create_local_controller(session, host, password)`.
+     - *Instantiation:* Call `create_controller(session, host, password)`.
    - **Port 443 Open (HTTPS):** The device is running upgraded/newer firmware.
      - *Client Action:* Inform the user that they must sign in using their Rain Bird cloud account.
      - *Next Step:* Redirect to **Journey B**.
@@ -153,16 +153,16 @@ Depending on how the user connects their device, the home automation client runs
 
 ### A. Local Controller Factory
 ```python
-from pyrainbird.async_client import create_local_controller
+from pyrainbird.async_client import create_controller
 
 # Instantiates local controller (auto-probes and handles HTTP or HTTPS+AES transparently)
-controller = await create_local_controller(
+controller = await create_controller(
     session=clientsession,
     host="192.168.1.15",
     password="my_device_password",
 )
 ```
-- **Returns:** `AsyncRainbirdLocalController` (implements `RainbirdController`).
+- **Returns:** `AsyncRainbirdController` (implements `RainbirdController`).
 - **Features supported:** Typically `{ControllerFeature.RAIN_DELAY, ControllerFeature.SEASONAL_ADJUST, ControllerFeature.ZONE_IRRIGATION, ControllerFeature.CALENDAR_SCHEDULE}`.
 
 ### B. Cloud Authentication Helper

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -153,7 +153,6 @@ class RainbirdTokenProvider:
 __all__ = [
     "CreateController",
     "create_controller",
-    "create_local_controller",
     "AsyncRainbirdController",
     "ControllerFeature",
     "RainbirdController",
@@ -749,8 +748,3 @@ class AsyncRainbirdController(RainbirdController):
         if self._model and self._model.model_info:
             return self._model.model_info.max_programs
         return 0
-
-
-# Alias create_local_controller directly to create_controller since AsyncRainbirdController
-# now implements the RainbirdController interface directly.
-create_local_controller = create_controller

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -155,7 +155,6 @@ __all__ = [
     "create_controller",
     "create_local_controller",
     "AsyncRainbirdController",
-    "AsyncRainbirdLocalController",
     "ControllerFeature",
     "RainbirdController",
     "RainbirdTokenProvider",
@@ -328,7 +327,7 @@ async def create_controller(
         return await _probe(url=http_url, ssl_context=None)
 
 
-class AsyncRainbirdController:
+class AsyncRainbirdController(RainbirdController):
     """Rainbird controller that uses asyncio."""
 
     def __init__(
@@ -727,10 +726,6 @@ class AsyncRainbirdController:
         self._cache[key] = result
         return result  # type: ignore
 
-
-class AsyncRainbirdLocalController(AsyncRainbirdController, RainbirdController):
-    """Local Rain Bird controller client implementing RainbirdController capabilities."""
-
     @property
     def supported_features(self) -> set[ControllerFeature]:
         """Return the features supported by this specific controller."""
@@ -756,36 +751,6 @@ class AsyncRainbirdLocalController(AsyncRainbirdController, RainbirdController):
         return 0
 
 
-async def create_local_controller(
-    session: aiohttp.ClientSession, host: str, password: str
-) -> AsyncRainbirdLocalController:
-    """Create an AsyncRainbirdLocalController with local HTTP/HTTPS discovery.
-
-    The local Rain Bird controller API appears to vary by firmware. Some devices
-    accept HTTP on port 80, while others require HTTPS (commonly with a
-    self-signed certificate). This factory probes the controller to determine
-    the correct scheme while keeping the public API hostname-based.
-    """
-    host = host.strip()
-    host = host.rstrip("/")
-
-    async def _probe(
-        *, url: str, ssl_context: ssl.SSLContext | bool | None
-    ) -> AsyncRainbirdLocalController:
-        local_client = AsyncRainbirdClient(
-            session,
-            url,
-            password,
-            ssl_context=ssl_context,
-        )
-        controller = AsyncRainbirdLocalController(local_client)
-        await controller.get_model_and_version()
-        return controller
-
-    https_url = f"https://{host}/stick"
-    http_url = f"http://{host}/stick"
-    try:
-        return await _probe(url=https_url, ssl_context=False)
-    except RainbirdConnectionError:
-        # Likely wrong scheme (device doesn't speak TLS); fall back to HTTP.
-        return await _probe(url=http_url, ssl_context=None)
+# Alias create_local_controller directly to create_controller since AsyncRainbirdController
+# now implements the RainbirdController interface directly.
+create_local_controller = create_controller

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -153,7 +153,9 @@ class RainbirdTokenProvider:
 __all__ = [
     "CreateController",
     "create_controller",
+    "create_local_controller",
     "AsyncRainbirdController",
+    "AsyncRainbirdLocalController",
     "ControllerFeature",
     "RainbirdController",
     "RainbirdTokenProvider",
@@ -724,3 +726,66 @@ class AsyncRainbirdController:
         result = await self._process_command(funct, command, *args)
         self._cache[key] = result
         return result  # type: ignore
+
+
+class AsyncRainbirdLocalController(AsyncRainbirdController, RainbirdController):
+    """Local Rain Bird controller client implementing RainbirdController capabilities."""
+
+    @property
+    def supported_features(self) -> set[ControllerFeature]:
+        """Return the features supported by this specific controller."""
+        return {
+            ControllerFeature.RAIN_DELAY,
+            ControllerFeature.SEASONAL_ADJUST,
+            ControllerFeature.ZONE_IRRIGATION,
+            ControllerFeature.CALENDAR_SCHEDULE,
+        }
+
+    @property
+    def max_zones(self) -> int:
+        """Return the maximum number of stations/zones supported."""
+        if self._model and self._model.model_info:
+            return self._model.model_info.max_stations
+        return 0
+
+    @property
+    def max_programs(self) -> int:
+        """Return the maximum number of programs supported."""
+        if self._model and self._model.model_info:
+            return self._model.model_info.max_programs
+        return 0
+
+
+async def create_local_controller(
+    session: aiohttp.ClientSession, host: str, password: str
+) -> AsyncRainbirdLocalController:
+    """Create an AsyncRainbirdLocalController with local HTTP/HTTPS discovery.
+
+    The local Rain Bird controller API appears to vary by firmware. Some devices
+    accept HTTP on port 80, while others require HTTPS (commonly with a
+    self-signed certificate). This factory probes the controller to determine
+    the correct scheme while keeping the public API hostname-based.
+    """
+    host = host.strip()
+    host = host.rstrip("/")
+
+    async def _probe(
+        *, url: str, ssl_context: ssl.SSLContext | bool | None
+    ) -> AsyncRainbirdLocalController:
+        local_client = AsyncRainbirdClient(
+            session,
+            url,
+            password,
+            ssl_context=ssl_context,
+        )
+        controller = AsyncRainbirdLocalController(local_client)
+        await controller.get_model_and_version()
+        return controller
+
+    https_url = f"https://{host}/stick"
+    http_url = f"http://{host}/stick"
+    try:
+        return await _probe(url=https_url, ssl_context=False)
+    except RainbirdConnectionError:
+        # Likely wrong scheme (device doesn't speak TLS); fall back to HTTP.
+        return await _probe(url=http_url, ssl_context=None)

--- a/tests/__snapshots__/test_async_client.ambr
+++ b/tests/__snapshots__/test_async_client.ambr
@@ -35,6 +35,18 @@
   list([
   ])
 # ---
+# name: test_create_local_controller_does_not_fallback_on_auth_error
+  list([
+  ])
+# ---
+# name: test_create_local_controller_tries_https_then_http_on_connection_error
+  list([
+  ])
+# ---
+# name: test_create_local_controller_tries_insecure_https_first
+  list([
+  ])
+# ---
 # name: test_custom_schedule
   '''
   [client >]
@@ -8136,6 +8148,10 @@
     "id": 1
   }
   '''
+# ---
+# name: test_local_controller_capabilities
+  list([
+  ])
 # ---
 # name: test_non_retryable_errors
   '''

--- a/tests/__snapshots__/test_async_client.ambr
+++ b/tests/__snapshots__/test_async_client.ambr
@@ -35,18 +35,6 @@
   list([
   ])
 # ---
-# name: test_create_local_controller_does_not_fallback_on_auth_error
-  list([
-  ])
-# ---
-# name: test_create_local_controller_tries_https_then_http_on_connection_error
-  list([
-  ])
-# ---
-# name: test_create_local_controller_tries_insecure_https_first
-  list([
-  ])
-# ---
 # name: test_custom_schedule
   '''
   [client >]

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -15,7 +15,6 @@ from freezegun import freeze_time
 from pyrainbird.async_client import (
     AsyncRainbirdClient,
     AsyncRainbirdController,
-    AsyncRainbirdLocalController,
     ControllerFeature,
     create_controller,
     create_local_controller,
@@ -1778,13 +1777,14 @@ async def test_create_local_controller_tries_insecure_https_first() -> None:
     with (
         mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
         mock.patch(
-            "pyrainbird.async_client.AsyncRainbirdLocalController.get_model_and_version",
+            "pyrainbird.async_client.AsyncRainbirdController.get_model_and_version",
             new=mock.AsyncMock(return_value=ModelAndVersion(0x0A, 1, 3)),
         ),
     ):
         await create_local_controller(session, "example.com", "password")
 
     assert client_cls.call_args_list == [
+        mock.call(session, mock.ANY, None),
         mock.call(session, "https://example.com/stick", "password", ssl_context=False),
     ]
 
@@ -1797,7 +1797,7 @@ async def test_create_local_controller_tries_https_then_http_on_connection_error
     with (
         mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
         mock.patch(
-            "pyrainbird.async_client.AsyncRainbirdLocalController.get_model_and_version",
+            "pyrainbird.async_client.AsyncRainbirdController.get_model_and_version",
             new=mock.AsyncMock(
                 side_effect=[
                     RainbirdConnectionError("connect error"),
@@ -1809,6 +1809,7 @@ async def test_create_local_controller_tries_https_then_http_on_connection_error
         await create_local_controller(session, "example.com", "password")
 
     assert client_cls.call_args_list == [
+        mock.call(session, mock.ANY, None),
         mock.call(session, "https://example.com/stick", "password", ssl_context=False),
         mock.call(session, "http://example.com/stick", "password", ssl_context=None),
     ]
@@ -1820,7 +1821,7 @@ async def test_create_local_controller_does_not_fallback_on_auth_error() -> None
     with (
         mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
         mock.patch(
-            "pyrainbird.async_client.AsyncRainbirdLocalController.get_model_and_version",
+            "pyrainbird.async_client.AsyncRainbirdController.get_model_and_version",
             new=mock.AsyncMock(side_effect=RainbirdAuthException("bad password")),
         ),
     ):
@@ -1828,13 +1829,14 @@ async def test_create_local_controller_does_not_fallback_on_auth_error() -> None
             await create_local_controller(session, "example.com", "password")
 
     assert client_cls.call_args_list == [
+        mock.call(session, mock.ANY, None),
         mock.call(session, "https://example.com/stick", "password", ssl_context=False),
     ]
 
 
 async def test_local_controller_capabilities() -> None:
     local_client = mock.Mock()
-    controller = AsyncRainbirdLocalController(local_client)
+    controller = AsyncRainbirdController(local_client)
 
     # Before model_info is loaded:
     assert controller.max_zones == 0

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -15,7 +15,10 @@ from freezegun import freeze_time
 from pyrainbird.async_client import (
     AsyncRainbirdClient,
     AsyncRainbirdController,
+    AsyncRainbirdLocalController,
+    ControllerFeature,
     create_controller,
+    create_local_controller,
 )
 from pyrainbird.data import (
     DayOfWeek,
@@ -1767,3 +1770,85 @@ async def test_get_schedule_partial_nack(
     assert program.durations[2].duration == datetime.timedelta(minutes=5)
     assert program.durations[3].zone == 4
     assert program.durations[3].duration == datetime.timedelta(minutes=5)
+
+
+async def test_create_local_controller_tries_insecure_https_first() -> None:
+    session = mock.AsyncMock(spec=aiohttp.ClientSession)
+
+    with (
+        mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
+        mock.patch(
+            "pyrainbird.async_client.AsyncRainbirdLocalController.get_model_and_version",
+            new=mock.AsyncMock(return_value=ModelAndVersion(0x0A, 1, 3)),
+        ),
+    ):
+        await create_local_controller(session, "example.com", "password")
+
+    assert client_cls.call_args_list == [
+        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
+    ]
+
+
+async def test_create_local_controller_tries_https_then_http_on_connection_error() -> (
+    None
+):
+    session = mock.AsyncMock(spec=aiohttp.ClientSession)
+
+    with (
+        mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
+        mock.patch(
+            "pyrainbird.async_client.AsyncRainbirdLocalController.get_model_and_version",
+            new=mock.AsyncMock(
+                side_effect=[
+                    RainbirdConnectionError("connect error"),
+                    ModelAndVersion(0x0A, 1, 3),
+                ]
+            ),
+        ),
+    ):
+        await create_local_controller(session, "example.com", "password")
+
+    assert client_cls.call_args_list == [
+        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
+        mock.call(session, "http://example.com/stick", "password", ssl_context=None),
+    ]
+
+
+async def test_create_local_controller_does_not_fallback_on_auth_error() -> None:
+    session = mock.AsyncMock(spec=aiohttp.ClientSession)
+
+    with (
+        mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
+        mock.patch(
+            "pyrainbird.async_client.AsyncRainbirdLocalController.get_model_and_version",
+            new=mock.AsyncMock(side_effect=RainbirdAuthException("bad password")),
+        ),
+    ):
+        with pytest.raises(RainbirdAuthException):
+            await create_local_controller(session, "example.com", "password")
+
+    assert client_cls.call_args_list == [
+        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
+    ]
+
+
+async def test_local_controller_capabilities() -> None:
+    local_client = mock.Mock()
+    controller = AsyncRainbirdLocalController(local_client)
+
+    # Before model_info is loaded:
+    assert controller.max_zones == 0
+    assert controller.max_programs == 0
+
+    # Assert base capabilities are supported
+    assert controller.supported_features == {
+        ControllerFeature.RAIN_DELAY,
+        ControllerFeature.SEASONAL_ADJUST,
+        ControllerFeature.ZONE_IRRIGATION,
+        ControllerFeature.CALENDAR_SCHEDULE,
+    }
+
+    # Set model info (ESP-TM2)
+    controller._model = ModelAndVersion(0x0A, 1, 3)
+    assert controller.max_zones == 12
+    assert controller.max_programs == 3

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -17,7 +17,6 @@ from pyrainbird.async_client import (
     AsyncRainbirdController,
     ControllerFeature,
     create_controller,
-    create_local_controller,
 )
 from pyrainbird.data import (
     DayOfWeek,
@@ -1769,69 +1768,6 @@ async def test_get_schedule_partial_nack(
     assert program.durations[2].duration == datetime.timedelta(minutes=5)
     assert program.durations[3].zone == 4
     assert program.durations[3].duration == datetime.timedelta(minutes=5)
-
-
-async def test_create_local_controller_tries_insecure_https_first() -> None:
-    session = mock.AsyncMock(spec=aiohttp.ClientSession)
-
-    with (
-        mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
-        mock.patch(
-            "pyrainbird.async_client.AsyncRainbirdController.get_model_and_version",
-            new=mock.AsyncMock(return_value=ModelAndVersion(0x0A, 1, 3)),
-        ),
-    ):
-        await create_local_controller(session, "example.com", "password")
-
-    assert client_cls.call_args_list == [
-        mock.call(session, mock.ANY, None),
-        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
-    ]
-
-
-async def test_create_local_controller_tries_https_then_http_on_connection_error() -> (
-    None
-):
-    session = mock.AsyncMock(spec=aiohttp.ClientSession)
-
-    with (
-        mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
-        mock.patch(
-            "pyrainbird.async_client.AsyncRainbirdController.get_model_and_version",
-            new=mock.AsyncMock(
-                side_effect=[
-                    RainbirdConnectionError("connect error"),
-                    ModelAndVersion(0x0A, 1, 3),
-                ]
-            ),
-        ),
-    ):
-        await create_local_controller(session, "example.com", "password")
-
-    assert client_cls.call_args_list == [
-        mock.call(session, mock.ANY, None),
-        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
-        mock.call(session, "http://example.com/stick", "password", ssl_context=None),
-    ]
-
-
-async def test_create_local_controller_does_not_fallback_on_auth_error() -> None:
-    session = mock.AsyncMock(spec=aiohttp.ClientSession)
-
-    with (
-        mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
-        mock.patch(
-            "pyrainbird.async_client.AsyncRainbirdController.get_model_and_version",
-            new=mock.AsyncMock(side_effect=RainbirdAuthException("bad password")),
-        ),
-    ):
-        with pytest.raises(RainbirdAuthException):
-            await create_local_controller(session, "example.com", "password")
-
-    assert client_cls.call_args_list == [
-        mock.call(session, mock.ANY, None),
-        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
-    ]
 
 
 async def test_local_controller_capabilities() -> None:


### PR DESCRIPTION
This PR implements the local controller capability properties directly on `AsyncRainbirdController`.

It updates:
- `AsyncRainbirdController` to directly inherit `RainbirdController`
- Capability properties: `supported_features`, `max_zones`, and `max_programs`
- Unit tests and documentation

Closes #567