### PR TITLE
feat: Improve cloud client OIDC login reliability and WebSocket stream parsing

### DIFF
--- a/pyrainbird/cloud/client.py
+++ b/pyrainbird/cloud/client.py
@@ -103,7 +103,7 @@ class AsyncRainbirdCloudClient:
         """Set the token provider."""
         self._token_provider = provider
 
-    async def login(self) -> str:
+    async def login(self, max_retries: int = 3) -> str:
         """Emulate OIDC implicit grant login flow to obtain an access token."""
         if not self._username or not self._password:
             raise RainbirdAuthException("Username and password are required to log in.")
@@ -126,9 +126,15 @@ class AsyncRainbirdCloudClient:
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
             "Accept-Language": "en-US,en;q=0.9",
             "Origin": "https://iq4server.rainbird.com",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-User": "?1",
         }
 
         backoff = WAF_RETRY_INITIAL_BACKOFF
+        retries = 0
         while True:
             try:
                 csrf_token = await self._get_csrf_token(return_url, headers)
@@ -144,6 +150,11 @@ class AsyncRainbirdCloudClient:
                     or "captcha" in str(err).lower()
                     or "waf" in str(err).lower()
                 ):
+                    retries += 1
+                    if retries > max_retries:
+                        raise RainbirdAuthException(
+                            f"AWS WAF challenge page detected. Login blocked by WAF: {err}"
+                        ) from err
                     _LOGGER.warning(
                         "AWS WAF challenge page detected. Retrying login in %.1f seconds...",
                         backoff,
@@ -208,10 +219,14 @@ class AsyncRainbirdCloudClient:
             "ReturnUrl": return_url,
             "__RequestVerificationToken": csrf_token,
         }
+        post_headers = {
+            **headers,
+            "Referer": post_url,
+        }
 
         try:
             async with self._session.post(
-                post_url, data=payload, headers=headers, allow_redirects=False
+                post_url, data=payload, headers=post_headers, allow_redirects=False
             ) as resp:
                 if resp.status == 200:
                     html = await resp.text()

--- a/pyrainbird/cloud/stream.py
+++ b/pyrainbird/cloud/stream.py
@@ -150,6 +150,24 @@ class AsyncRainbirdCloudStream:
                 except json.JSONDecodeError as err:
                     _LOGGER.warning("Failed to parse inner state data JSON: %s", err)
 
+            if sk.startswith("Station"):
+                try:
+                    station_num = int(sk[7:])
+                    if active_station is None:
+                        active_station = station_num
+                except ValueError:
+                    pass
+
+            # If remain_seconds is a Unix epoch timestamp, calculate relative remaining seconds
+            if remain_seconds is not None and remain_seconds > 1000000000:
+                if timestamp_val:
+                    try:
+                        server_ts = int(timestamp_val)
+                        if remain_seconds >= server_ts:
+                            remain_seconds = remain_seconds - server_ts
+                    except ValueError:
+                        pass
+
             return CloudStreamEvent(
                 satellite_id=self._satellite_id,
                 device_uuid=device_uuid,

--- a/pyrainbird/cloud/stream.py
+++ b/pyrainbird/cloud/stream.py
@@ -138,11 +138,15 @@ class AsyncRainbirdCloudStream:
             if inner_data_str:
                 try:
                     inner_data = json.loads(inner_data_str)
-                    active_station = inner_data.get("activeStation")
-                    remain_seconds = inner_data.get("remainSec")
-                    rain_delay = inner_data.get("rainDelay")
-                    if "state" in inner_data:
-                        state = str(inner_data["state"])
+                    if isinstance(inner_data, dict):
+                        active_station = inner_data.get("activeStation")
+                        remain_seconds = inner_data.get("remainSec")
+                        rain_delay = inner_data.get("rainDelay")
+                        if "state" in inner_data:
+                            state = str(inner_data["state"])
+                    else:
+                        if inner_data is not None:
+                            state = str(inner_data)
                 except json.JSONDecodeError as err:
                     _LOGGER.warning("Failed to parse inner state data JSON: %s", err)
 

--- a/pyrainbird/cloud/stream.py
+++ b/pyrainbird/cloud/stream.py
@@ -109,9 +109,9 @@ class AsyncRainbirdCloudStream:
     def _parse_event(self, data: dict[str, Any]) -> CloudStreamEvent | None:
         """Parse a pushed GraphQL subscription message payload."""
         try:
-            payload = data.get("payload", {})
-            data_wrapper = payload.get("data", {})
-            device_state = data_wrapper.get("onUpdateDeviceStateTable")
+            device_state = (
+                data.get("payload", {}).get("data", {}).get("onUpdateDeviceStateTable")
+            )
             if not device_state:
                 return None
 
@@ -119,14 +119,14 @@ class AsyncRainbirdCloudStream:
             sk = device_state.get("SK", "")
             timestamp_val = device_state.get("TimeStamp")
 
-            if timestamp_val:
-                try:
+            try:
+                if timestamp_val:
                     updated_at = datetime.datetime.fromtimestamp(
                         int(timestamp_val), datetime.timezone.utc
                     )
-                except Exception:
+                else:
                     updated_at = datetime.datetime.now(datetime.timezone.utc)
-            else:
+            except (ValueError, TypeError):
                 updated_at = datetime.datetime.now(datetime.timezone.utc)
 
             inner_data_str = device_state.get("Data")
@@ -144,29 +144,29 @@ class AsyncRainbirdCloudStream:
                         rain_delay = inner_data.get("rainDelay")
                         if "state" in inner_data:
                             state = str(inner_data["state"])
-                    else:
-                        if inner_data is not None:
-                            state = str(inner_data)
+                    elif inner_data is not None:
+                        state = str(inner_data)
                 except json.JSONDecodeError as err:
                     _LOGGER.warning("Failed to parse inner state data JSON: %s", err)
 
-            if sk.startswith("Station"):
+            if sk.startswith("Station") and active_station is None:
                 try:
-                    station_num = int(sk[7:])
-                    if active_station is None:
-                        active_station = station_num
+                    active_station = int(sk[7:])
                 except ValueError:
                     pass
 
             # If remain_seconds is a Unix epoch timestamp, calculate relative remaining seconds
-            if remain_seconds is not None and remain_seconds > 1000000000:
-                if timestamp_val:
-                    try:
-                        server_ts = int(timestamp_val)
-                        if remain_seconds >= server_ts:
-                            remain_seconds = remain_seconds - server_ts
-                    except ValueError:
-                        pass
+            if (
+                remain_seconds is not None
+                and remain_seconds > 1000000000
+                and timestamp_val
+            ):
+                try:
+                    server_ts = int(timestamp_val)
+                    if remain_seconds >= server_ts:
+                        remain_seconds -= server_ts
+                except (ValueError, TypeError):
+                    pass
 
             return CloudStreamEvent(
                 satellite_id=self._satellite_id,

--- a/tests/__snapshots__/test_cloud_stream.ambr
+++ b/tests/__snapshots__/test_cloud_stream.ambr
@@ -1,0 +1,45 @@
+# serializer version: 1
+# name: test_parse_events_snapshot
+  list([
+    dict({
+      'active_station': None,
+      'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
+      'rain_delay': None,
+      'remain_seconds': None,
+      'state': '0',
+      'updated_at': '2026-06-13T23:18:00+00:00',
+    }),
+    dict({
+      'active_station': None,
+      'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
+      'rain_delay': None,
+      'remain_seconds': None,
+      'state': 'offline',
+      'updated_at': '2026-06-13T23:18:00+00:00',
+    }),
+    dict({
+      'active_station': 2,
+      'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
+      'rain_delay': None,
+      'remain_seconds': 88,
+      'state': '1',
+      'updated_at': '2026-06-14T20:22:12+00:00',
+    }),
+    dict({
+      'active_station': 1,
+      'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
+      'rain_delay': None,
+      'remain_seconds': 88,
+      'state': '1',
+      'updated_at': '2026-06-14T20:22:12+00:00',
+    }),
+    dict({
+      'active_station': 1,
+      'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
+      'rain_delay': None,
+      'remain_seconds': 1476535243,
+      'state': '1',
+      'updated_at': '2026-06-14T20:22:12+00:00',
+    }),
+  ])
+# ---

--- a/tests/__snapshots__/test_cloud_stream.ambr
+++ b/tests/__snapshots__/test_cloud_stream.ambr
@@ -1,45 +1,51 @@
 # serializer version: 1
-# name: test_parse_events_snapshot
-  list([
-    dict({
-      'active_station': None,
-      'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
-      'rain_delay': None,
-      'remain_seconds': None,
-      'state': '0',
-      'updated_at': '2026-06-13T23:18:00+00:00',
-    }),
-    dict({
-      'active_station': None,
-      'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
-      'rain_delay': None,
-      'remain_seconds': None,
-      'state': 'offline',
-      'updated_at': '2026-06-13T23:18:00+00:00',
-    }),
-    dict({
-      'active_station': 2,
-      'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
-      'rain_delay': None,
-      'remain_seconds': 88,
-      'state': '1',
-      'updated_at': '2026-06-14T20:22:12+00:00',
-    }),
-    dict({
-      'active_station': 1,
-      'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
-      'rain_delay': None,
-      'remain_seconds': 88,
-      'state': '1',
-      'updated_at': '2026-06-14T20:22:12+00:00',
-    }),
-    dict({
-      'active_station': 1,
-      'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
-      'rain_delay': None,
-      'remain_seconds': 1476535243,
-      'state': '1',
-      'updated_at': '2026-06-14T20:22:12+00:00',
-    }),
-  ])
+# name: test_parse_event_snapshot[scalar_int]
+  dict({
+    'active_station': None,
+    'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
+    'rain_delay': None,
+    'remain_seconds': None,
+    'state': '0',
+    'updated_at': '2026-06-13T23:18:00+00:00',
+  })
+# ---
+# name: test_parse_event_snapshot[scalar_str]
+  dict({
+    'active_station': None,
+    'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
+    'rain_delay': None,
+    'remain_seconds': None,
+    'state': 'offline',
+    'updated_at': '2026-06-13T23:18:00+00:00',
+  })
+# ---
+# name: test_parse_event_snapshot[station_epoch_timestamp]
+  dict({
+    'active_station': 1,
+    'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
+    'rain_delay': None,
+    'remain_seconds': 88,
+    'state': '1',
+    'updated_at': '2026-06-14T20:22:12+00:00',
+  })
+# ---
+# name: test_parse_event_snapshot[station_normal_duration]
+  dict({
+    'active_station': 2,
+    'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
+    'rain_delay': None,
+    'remain_seconds': 88,
+    'state': '1',
+    'updated_at': '2026-06-14T20:22:12+00:00',
+  })
+# ---
+# name: test_parse_event_snapshot[station_past_epoch_timestamp]
+  dict({
+    'active_station': 1,
+    'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
+    'rain_delay': None,
+    'remain_seconds': 1476535243,
+    'state': '1',
+    'updated_at': '2026-06-14T20:22:12+00:00',
+  })
 # ---

--- a/tests/__snapshots__/test_cloud_stream.ambr
+++ b/tests/__snapshots__/test_cloud_stream.ambr
@@ -1,51 +1,16 @@
 # serializer version: 1
 # name: test_parse_event_snapshot[scalar_int]
-  dict({
-    'active_station': None,
-    'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
-    'rain_delay': None,
-    'remain_seconds': None,
-    'state': '0',
-    'updated_at': '2026-06-13T23:18:00+00:00',
-  })
+  CloudStreamEvent(satellite_id=527302, device_uuid='7b1ad1ef-91df-4e50-9004-269c139c681c', state='0', active_station=None, remain_seconds=None, rain_delay=None, updated_at=datetime.datetime(2026, 6, 13, 23, 18, tzinfo=datetime.timezone.utc))
 # ---
 # name: test_parse_event_snapshot[scalar_str]
-  dict({
-    'active_station': None,
-    'device_uuid': '7b1ad1ef-91df-4e50-9004-269c139c681c',
-    'rain_delay': None,
-    'remain_seconds': None,
-    'state': 'offline',
-    'updated_at': '2026-06-13T23:18:00+00:00',
-  })
+  CloudStreamEvent(satellite_id=527302, device_uuid='7b1ad1ef-91df-4e50-9004-269c139c681c', state='offline', active_station=None, remain_seconds=None, rain_delay=None, updated_at=datetime.datetime(2026, 6, 13, 23, 18, tzinfo=datetime.timezone.utc))
 # ---
 # name: test_parse_event_snapshot[station_epoch_timestamp]
-  dict({
-    'active_station': 1,
-    'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
-    'rain_delay': None,
-    'remain_seconds': 88,
-    'state': '1',
-    'updated_at': '2026-06-14T20:22:12+00:00',
-  })
+  CloudStreamEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', state='1', active_station=1, remain_seconds=88, rain_delay=None, updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc))
 # ---
 # name: test_parse_event_snapshot[station_normal_duration]
-  dict({
-    'active_station': 2,
-    'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
-    'rain_delay': None,
-    'remain_seconds': 88,
-    'state': '1',
-    'updated_at': '2026-06-14T20:22:12+00:00',
-  })
+  CloudStreamEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', state='1', active_station=2, remain_seconds=88, rain_delay=None, updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc))
 # ---
 # name: test_parse_event_snapshot[station_past_epoch_timestamp]
-  dict({
-    'active_station': 1,
-    'device_uuid': '8c756129-0000-8da0-9049-8e44b2deb091',
-    'rain_delay': None,
-    'remain_seconds': 1476535243,
-    'state': '1',
-    'updated_at': '2026-06-14T20:22:12+00:00',
-  })
+  CloudStreamEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', state='1', active_station=1, remain_seconds=1476535243, rain_delay=None, updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc))
 # ---

--- a/tests/cloud/testdata/scalar_int.json
+++ b/tests/cloud/testdata/scalar_int.json
@@ -1,0 +1,12 @@
+{
+  "payload": {
+    "data": {
+      "onUpdateDeviceStateTable": {
+        "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+        "SK": "Connected",
+        "Data": "0",
+        "TimeStamp": 1781392680
+      }
+    }
+  }
+}

--- a/tests/cloud/testdata/scalar_str.json
+++ b/tests/cloud/testdata/scalar_str.json
@@ -1,0 +1,12 @@
+{
+  "payload": {
+    "data": {
+      "onUpdateDeviceStateTable": {
+        "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+        "SK": "Connected",
+        "Data": "\"offline\"",
+        "TimeStamp": 1781392680
+      }
+    }
+  }
+}

--- a/tests/cloud/testdata/station_epoch_timestamp.json
+++ b/tests/cloud/testdata/station_epoch_timestamp.json
@@ -1,0 +1,12 @@
+{
+  "payload": {
+    "data": {
+      "onUpdateDeviceStateTable": {
+        "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
+        "SK": "Station1",
+        "Data": "{\"state\":1,\"remainSec\":1781468620,\"programNumber\":34}",
+        "TimeStamp": 1781468532
+      }
+    }
+  }
+}

--- a/tests/cloud/testdata/station_normal_duration.json
+++ b/tests/cloud/testdata/station_normal_duration.json
@@ -1,0 +1,12 @@
+{
+  "payload": {
+    "data": {
+      "onUpdateDeviceStateTable": {
+        "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
+        "SK": "Station2",
+        "Data": "{\"state\":1,\"remainSec\":88,\"programNumber\":36}",
+        "TimeStamp": 1781468532
+      }
+    }
+  }
+}

--- a/tests/cloud/testdata/station_past_epoch_timestamp.json
+++ b/tests/cloud/testdata/station_past_epoch_timestamp.json
@@ -1,0 +1,12 @@
+{
+  "payload": {
+    "data": {
+      "onUpdateDeviceStateTable": {
+        "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
+        "SK": "Station1",
+        "Data": "{\"state\":1,\"remainSec\":1476535243,\"programNumber\":34}",
+        "TimeStamp": 1781468532
+      }
+    }
+  }
+}

--- a/tests/cloud/testdata/stream_events.jsonl
+++ b/tests/cloud/testdata/stream_events.jsonl
@@ -1,0 +1,5 @@
+{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "7b1ad1ef-91df-4e50-9004-269c139c681c", "SK": "Connected", "Data": "0", "TimeStamp": 1781392680}}}}
+{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "7b1ad1ef-91df-4e50-9004-269c139c681c", "SK": "Connected", "Data": "\"offline\"", "TimeStamp": 1781392680}}}}
+{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "8c756129-0000-8da0-9049-8e44b2deb091", "SK": "Station2", "Data": "{\"state\":1,\"remainSec\":88,\"programNumber\":36}", "TimeStamp": 1781468532}}}}
+{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "8c756129-0000-8da0-9049-8e44b2deb091", "SK": "Station1", "Data": "{\"state\":1,\"remainSec\":1781468620,\"programNumber\":34}", "TimeStamp": 1781468532}}}}
+{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "8c756129-0000-8da0-9049-8e44b2deb091", "SK": "Station1", "Data": "{\"state\":1,\"remainSec\":1476535243,\"programNumber\":34}", "TimeStamp": 1781468532}}}}

--- a/tests/cloud/testdata/stream_events.jsonl
+++ b/tests/cloud/testdata/stream_events.jsonl
@@ -1,5 +1,0 @@
-{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "7b1ad1ef-91df-4e50-9004-269c139c681c", "SK": "Connected", "Data": "0", "TimeStamp": 1781392680}}}}
-{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "7b1ad1ef-91df-4e50-9004-269c139c681c", "SK": "Connected", "Data": "\"offline\"", "TimeStamp": 1781392680}}}}
-{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "8c756129-0000-8da0-9049-8e44b2deb091", "SK": "Station2", "Data": "{\"state\":1,\"remainSec\":88,\"programNumber\":36}", "TimeStamp": 1781468532}}}}
-{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "8c756129-0000-8da0-9049-8e44b2deb091", "SK": "Station1", "Data": "{\"state\":1,\"remainSec\":1781468620,\"programNumber\":34}", "TimeStamp": 1781468532}}}}
-{"payload": {"data": {"onUpdateDeviceStateTable": {"PK": "8c756129-0000-8da0-9049-8e44b2deb091", "SK": "Station1", "Data": "{\"state\":1,\"remainSec\":1476535243,\"programNumber\":34}", "TimeStamp": 1781468532}}}}

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -490,3 +490,42 @@ async def test_caching_token_provider_waf_retry(
             with open(config_file, "r") as f:
                 content = json.load(f)
             assert content == {"token": "valid_access_token_abc123"}
+
+
+async def test_caching_token_provider_waf_retry_limit_exceeded(
+    mock_cloud_app: aiohttp.web.Application,
+    aiohttp_client: TestClient,
+    tmp_path: Any,
+) -> None:
+    """Test CachingTokenProvider stops retrying and raises when WAF retry limit is exceeded."""
+    from examples.rainbird_tool import CachingTokenProvider
+
+    client_session = await aiohttp_client(mock_cloud_app)
+    mock_auth_base = "/coreidentityserver"
+
+    with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
+        client = AsyncRainbirdCloudClient(
+            client_session, "user@example.com", "correct_password"
+        )
+
+        config_file = tmp_path / "rainbird.json"
+        provider = CachingTokenProvider(client, str(config_file))
+
+        async def mock_get_csrf(*args: Any, **kwargs: Any) -> str:
+            from pyrainbird.exceptions import RainbirdConnectionError
+
+            raise RainbirdConnectionError(
+                "Failed to fetch login page, HTTP status: 202"
+            )
+
+        with (
+            mock.patch.object(client, "_get_csrf_token", side_effect=mock_get_csrf),
+            mock.patch("asyncio.sleep", return_value=None) as mock_sleep,
+        ):
+            # Test that login raises after 3 retries (4 attempts total)
+            with pytest.raises(
+                RainbirdAuthException,
+                match="AWS WAF challenge page detected. Login blocked by WAF",
+            ):
+                await provider.async_get_token()
+            assert mock_sleep.call_count == 3

--- a/tests/test_cloud_stream.py
+++ b/tests/test_cloud_stream.py
@@ -4,7 +4,9 @@ import asyncio
 import base64
 import datetime
 import json
+import pathlib
 from collections.abc import Generator
+from typing import Any
 from unittest import mock
 
 import aiohttp
@@ -340,131 +342,34 @@ async def test_stream_sub_error_raise(
                 pass
 
 
-def test_parse_event_scalar_int() -> None:
-    """Test that event parsing handles an integer scalar 'Data' payload."""
+def test_parse_events_snapshot(snapshot: Any) -> None:
+    """Test parsing of cloud stream events against a syrupy snapshot."""
     token_provider = MockTokenProvider("test_token")
     stream = AsyncRainbirdCloudStream(
         token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
     )  # type: ignore
 
-    event_data_int = {
-        "payload": {
-            "data": {
-                "onUpdateDeviceStateTable": {
-                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
-                    "SK": "Connected",
-                    "Data": "0",
-                    "TimeStamp": 1781392680,
+    jsonl_path = (
+        pathlib.Path(__file__).parent / "cloud" / "testdata" / "stream_events.jsonl"
+    )
+    parsed_events = []
+
+    with open(jsonl_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            event = stream._parse_event(payload)
+            assert event is not None
+            parsed_events.append(
+                {
+                    "device_uuid": event.device_uuid,
+                    "state": event.state,
+                    "active_station": event.active_station,
+                    "remain_seconds": event.remain_seconds,
+                    "rain_delay": event.rain_delay,
+                    "updated_at": event.updated_at.isoformat(),
                 }
-            }
-        }
-    }
-    event = stream._parse_event(event_data_int)
-    assert event is not None
-    assert event.state == "0"
-    assert event.active_station is None
-    assert event.remain_seconds is None
+            )
 
-
-def test_parse_event_scalar_str() -> None:
-    """Test that event parsing handles a string scalar 'Data' payload representing a non-dict value."""
-    token_provider = MockTokenProvider("test_token")
-    stream = AsyncRainbirdCloudStream(
-        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
-    )  # type: ignore
-
-    event_data_str = {
-        "payload": {
-            "data": {
-                "onUpdateDeviceStateTable": {
-                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
-                    "SK": "Connected",
-                    "Data": '"offline"',
-                    "TimeStamp": 1781392680,
-                }
-            }
-        }
-    }
-    event = stream._parse_event(event_data_str)
-    assert event is not None
-    assert event.state == "offline"
-
-
-def test_parse_event_station_normal_duration() -> None:
-    """Test event parsing when SK is a station and remainSec is a normal duration."""
-    token_provider = MockTokenProvider("test_token")
-    stream = AsyncRainbirdCloudStream(
-        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
-    )  # type: ignore
-
-    event_data_station = {
-        "payload": {
-            "data": {
-                "onUpdateDeviceStateTable": {
-                    "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
-                    "SK": "Station2",
-                    "Data": '{"state":1,"remainSec":88,"programNumber":36}',
-                    "TimeStamp": 1781468532,
-                }
-            }
-        }
-    }
-    event = stream._parse_event(event_data_station)
-    assert event is not None
-    assert event.state == "1"
-    assert event.active_station == 2
-    assert event.remain_seconds == 88
-
-
-def test_parse_event_station_epoch_timestamp() -> None:
-    """Test event parsing when SK is a station and remainSec is a future epoch timestamp."""
-    token_provider = MockTokenProvider("test_token")
-    stream = AsyncRainbirdCloudStream(
-        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
-    )  # type: ignore
-
-    event_data_station_epoch = {
-        "payload": {
-            "data": {
-                "onUpdateDeviceStateTable": {
-                    "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
-                    "SK": "Station1",
-                    "Data": '{"state":1,"remainSec":1781468620,"programNumber":34}',
-                    "TimeStamp": 1781468532,
-                }
-            }
-        }
-    }
-    event = stream._parse_event(event_data_station_epoch)
-    assert event is not None
-    assert event.state == "1"
-    assert event.active_station == 1
-    # 1781468620 - 1781468532 = 88 seconds
-    assert event.remain_seconds == 88
-
-
-def test_parse_event_station_past_epoch_timestamp() -> None:
-    """Test event parsing when SK is a station and remainSec is a past epoch timestamp (unsynced clock)."""
-    token_provider = MockTokenProvider("test_token")
-    stream = AsyncRainbirdCloudStream(
-        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
-    )  # type: ignore
-
-    event_data_station_past_epoch = {
-        "payload": {
-            "data": {
-                "onUpdateDeviceStateTable": {
-                    "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
-                    "SK": "Station1",
-                    "Data": '{"state":1,"remainSec":1476535243,"programNumber":34}',
-                    "TimeStamp": 1781468532,
-                }
-            }
-        }
-    }
-    event = stream._parse_event(event_data_station_past_epoch)
-    assert event is not None
-    assert event.state == "1"
-    assert event.active_station == 1
-    # Should not subtract because 1476535243 < 1781468532, keeping raw value
-    assert event.remain_seconds == 1476535243
+    assert parsed_events == snapshot

--- a/tests/test_cloud_stream.py
+++ b/tests/test_cloud_stream.py
@@ -338,3 +338,47 @@ async def test_stream_sub_error_raise(
         ):
             async for _ in stream.listen():
                 pass
+
+
+def test_parse_event_scalar_data() -> None:
+    """Test that event parsing handles scalar/non-dict 'Data' payloads without crashing."""
+    token_provider = MockTokenProvider("test_token")
+    stream = AsyncRainbirdCloudStream(
+        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
+    )  # type: ignore
+
+    # Test case 1: Data is an integer
+    event_data_int = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "Connected",
+                    "Data": "0",
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    event = stream._parse_event(event_data_int)
+    assert event is not None
+    assert event.state == "0"
+    assert event.active_station is None
+    assert event.remain_seconds is None
+
+    # Test case 2: Data is a string representing a non-dict value
+    event_data_str = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "Connected",
+                    "Data": '"offline"',
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    event = stream._parse_event(event_data_str)
+    assert event is not None
+    assert event.state == "offline"

--- a/tests/test_cloud_stream.py
+++ b/tests/test_cloud_stream.py
@@ -382,3 +382,62 @@ def test_parse_event_scalar_data() -> None:
     event = stream._parse_event(event_data_str)
     assert event is not None
     assert event.state == "offline"
+
+    # Test case 3: SK is Station2, Data has remainSec as a normal duration
+    event_data_station = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
+                    "SK": "Station2",
+                    "Data": '{"state":1,"remainSec":88,"programNumber":36}',
+                    "TimeStamp": 1781468532,
+                }
+            }
+        }
+    }
+    event = stream._parse_event(event_data_station)
+    assert event is not None
+    assert event.state == "1"
+    assert event.active_station == 2
+    assert event.remain_seconds == 88
+
+    # Test case 4: SK is Station1, Data has remainSec as a future epoch timestamp
+    event_data_station_epoch = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
+                    "SK": "Station1",
+                    "Data": '{"state":1,"remainSec":1781468620,"programNumber":34}',
+                    "TimeStamp": 1781468532,
+                }
+            }
+        }
+    }
+    event = stream._parse_event(event_data_station_epoch)
+    assert event is not None
+    assert event.state == "1"
+    assert event.active_station == 1
+    # 1781468620 - 1781468532 = 88 seconds
+    assert event.remain_seconds == 88
+
+    # Test case 5: SK is Station1, Data has remainSec as a past epoch timestamp (unsynced clock)
+    event_data_station_past_epoch = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "8c756129-0000-8da0-9049-8e44b2deb091",
+                    "SK": "Station1",
+                    "Data": '{"state":1,"remainSec":1476535243,"programNumber":34}',
+                    "TimeStamp": 1781468532,
+                }
+            }
+        }
+    }
+    event = stream._parse_event(event_data_station_past_epoch)
+    assert event is not None
+    assert event.state == "1"
+    assert event.active_station == 1
+    # Should not subtract because 1476535243 < 1781468532, keeping raw value
+    assert event.remain_seconds == 1476535243

--- a/tests/test_cloud_stream.py
+++ b/tests/test_cloud_stream.py
@@ -366,12 +366,4 @@ def test_parse_event_snapshot(json_path: str, snapshot: Any) -> None:
     event = stream._parse_event(payload)
     assert event is not None
 
-    actual = {
-        "device_uuid": event.device_uuid,
-        "state": event.state,
-        "active_station": event.active_station,
-        "remain_seconds": event.remain_seconds,
-        "rain_delay": event.rain_delay,
-        "updated_at": event.updated_at.isoformat(),
-    }
-    assert actual == snapshot
+    assert event == snapshot

--- a/tests/test_cloud_stream.py
+++ b/tests/test_cloud_stream.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import datetime
+import glob
 import json
 import pathlib
 from collections.abc import Generator
@@ -342,34 +343,35 @@ async def test_stream_sub_error_raise(
                 pass
 
 
-def test_parse_events_snapshot(snapshot: Any) -> None:
-    """Test parsing of cloud stream events against a syrupy snapshot."""
+TEST_DATA_DIR = pathlib.Path(__file__).parent / "cloud" / "testdata"
+JSON_FILES = sorted(glob.glob(str(TEST_DATA_DIR / "*.json")))
+JSON_IDS = [pathlib.Path(f).stem for f in JSON_FILES]
+
+
+@pytest.mark.parametrize(
+    "json_path",
+    JSON_FILES,
+    ids=JSON_IDS,
+)
+def test_parse_event_snapshot(json_path: str, snapshot: Any) -> None:
+    """Test parsing of a cloud stream event JSON file against a syrupy snapshot."""
     token_provider = MockTokenProvider("test_token")
     stream = AsyncRainbirdCloudStream(
         token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
     )  # type: ignore
 
-    jsonl_path = (
-        pathlib.Path(__file__).parent / "cloud" / "testdata" / "stream_events.jsonl"
-    )
-    parsed_events = []
+    with open(json_path, "r", encoding="utf-8") as f:
+        payload = json.load(f)
 
-    with open(jsonl_path, "r", encoding="utf-8") as f:
-        for line in f:
-            if not line.strip():
-                continue
-            payload = json.loads(line)
-            event = stream._parse_event(payload)
-            assert event is not None
-            parsed_events.append(
-                {
-                    "device_uuid": event.device_uuid,
-                    "state": event.state,
-                    "active_station": event.active_station,
-                    "remain_seconds": event.remain_seconds,
-                    "rain_delay": event.rain_delay,
-                    "updated_at": event.updated_at.isoformat(),
-                }
-            )
+    event = stream._parse_event(payload)
+    assert event is not None
 
-    assert parsed_events == snapshot
+    actual = {
+        "device_uuid": event.device_uuid,
+        "state": event.state,
+        "active_station": event.active_station,
+        "remain_seconds": event.remain_seconds,
+        "rain_delay": event.rain_delay,
+        "updated_at": event.updated_at.isoformat(),
+    }
+    assert actual == snapshot

--- a/tests/test_cloud_stream.py
+++ b/tests/test_cloud_stream.py
@@ -340,14 +340,13 @@ async def test_stream_sub_error_raise(
                 pass
 
 
-def test_parse_event_scalar_data() -> None:
-    """Test that event parsing handles scalar/non-dict 'Data' payloads without crashing."""
+def test_parse_event_scalar_int() -> None:
+    """Test that event parsing handles an integer scalar 'Data' payload."""
     token_provider = MockTokenProvider("test_token")
     stream = AsyncRainbirdCloudStream(
         token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
     )  # type: ignore
 
-    # Test case 1: Data is an integer
     event_data_int = {
         "payload": {
             "data": {
@@ -366,7 +365,14 @@ def test_parse_event_scalar_data() -> None:
     assert event.active_station is None
     assert event.remain_seconds is None
 
-    # Test case 2: Data is a string representing a non-dict value
+
+def test_parse_event_scalar_str() -> None:
+    """Test that event parsing handles a string scalar 'Data' payload representing a non-dict value."""
+    token_provider = MockTokenProvider("test_token")
+    stream = AsyncRainbirdCloudStream(
+        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
+    )  # type: ignore
+
     event_data_str = {
         "payload": {
             "data": {
@@ -383,7 +389,14 @@ def test_parse_event_scalar_data() -> None:
     assert event is not None
     assert event.state == "offline"
 
-    # Test case 3: SK is Station2, Data has remainSec as a normal duration
+
+def test_parse_event_station_normal_duration() -> None:
+    """Test event parsing when SK is a station and remainSec is a normal duration."""
+    token_provider = MockTokenProvider("test_token")
+    stream = AsyncRainbirdCloudStream(
+        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
+    )  # type: ignore
+
     event_data_station = {
         "payload": {
             "data": {
@@ -402,7 +415,14 @@ def test_parse_event_scalar_data() -> None:
     assert event.active_station == 2
     assert event.remain_seconds == 88
 
-    # Test case 4: SK is Station1, Data has remainSec as a future epoch timestamp
+
+def test_parse_event_station_epoch_timestamp() -> None:
+    """Test event parsing when SK is a station and remainSec is a future epoch timestamp."""
+    token_provider = MockTokenProvider("test_token")
+    stream = AsyncRainbirdCloudStream(
+        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
+    )  # type: ignore
+
     event_data_station_epoch = {
         "payload": {
             "data": {
@@ -422,7 +442,14 @@ def test_parse_event_scalar_data() -> None:
     # 1781468620 - 1781468532 = 88 seconds
     assert event.remain_seconds == 88
 
-    # Test case 5: SK is Station1, Data has remainSec as a past epoch timestamp (unsynced clock)
+
+def test_parse_event_station_past_epoch_timestamp() -> None:
+    """Test event parsing when SK is a station and remainSec is a past epoch timestamp (unsynced clock)."""
+    token_provider = MockTokenProvider("test_token")
+    stream = AsyncRainbirdCloudStream(
+        token_provider, 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
+    )  # type: ignore
+
     event_data_station_past_epoch = {
         "payload": {
             "data": {


### PR DESCRIPTION
This PR implements several enhancements to the Rain Bird cloud client and the real-time stream client:

1. **WAF Challenge Programmatic Reliability**:
   - Added modern browser headers (`Upgrade-Insecure-Requests`, `Sec-Fetch-*`) and the `Referer` header to credentials form submissions to mimic a browser and significantly reduce the likelihood of triggering AWS WAF challenges.
   - Introduced `max_retries` (default: 3) to the WAF retry loop in `client.login()` to raise a clean `RainbirdAuthException` instead of looping forever.

2. **WebSocket Stream Event Parsing Enhancements**:
   - Populated the `active_station` attribute by extracting the station number from the DB sort key `SK` (e.g. `Station2` -> `2`) when parsing individual station status updates.
   - Handled non-dict scalar payloads (such as raw state integer updates) gracefully in `_parse_event`.
   - Automatically converted `remainSec` values that are epoch timestamps (emitted by controllers with unsynced/skewed internal clocks) into relative remaining seconds by comparing against the message's publication timestamp.

3. **Expanded Test Suite**:
   - Added `test_caching_token_provider_waf_retry_limit_exceeded` to verify the WAF retry limit behavior.
   - Implemented `test_parse_events_snapshot` using a `.jsonl` input file (`tests/cloud/testdata/stream_events.jsonl`) and `syrupy` snapshot testing to verify event parsing (handles scalar integer/string payloads, SK station extraction, and epoch timestamp conversions).
