### PR TITLE
feat: Add local discovery, mock simulator, and strongly-typed cloud stream events

### DIFF
--- a/examples/rainbird_tool.py
+++ b/examples/rainbird_tool.py
@@ -160,6 +160,82 @@ async def stream_cloud(
         print(f"Stream error: {err}")
 
 
+async def discover_local(timeout: float = 5.0) -> None:
+    """Broadcast UDP discovery ping to find controllers on the local network."""
+    import socket
+    import select
+
+    DISCOVERY_PAYLOAD = "RBD-ANDROID"
+    PORTS = [33667, 33668]
+
+    def do_discover():
+        # Ephemeral broadcast socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.setblocking(False)
+
+        # Upgraded socket listening on port 33668
+        upgraded_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            upgraded_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                upgraded_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            except AttributeError:
+                pass
+            upgraded_sock.bind(("0.0.0.0", 33668))
+            upgraded_sock.setblocking(False)
+            has_upgraded = True
+        except Exception as e:
+            _LOGGER.warning(
+                "Could not bind to port 33668 for upgraded discovery: %s", e
+            )
+            has_upgraded = False
+
+        print("Sending discovery broadcast for local Rain Bird devices...")
+        try:
+            import time
+
+            for port in PORTS:
+                sock.sendto(DISCOVERY_PAYLOAD.encode(), ("255.255.255.255", port))
+
+            print(f"Listening for responses for {timeout} seconds...")
+            start_time = time.time()
+            sockets_to_watch = [sock]
+            if has_upgraded:
+                sockets_to_watch.append(upgraded_sock)
+
+            while True:
+                elapsed = time.time() - start_time
+                remaining = timeout - elapsed
+                if remaining <= 0:
+                    break
+
+                readable, _, _ = select.select(
+                    sockets_to_watch, [], [], max(0.1, remaining)
+                )
+                for r_sock in readable:
+                    data, addr = r_sock.recvfrom(1024)
+                    mode = "Upgraded" if r_sock is upgraded_sock else "Legacy"
+                    print(f"\n[+] Found Device ({mode} Mode)!")
+                    print(f"    IP Address: {addr[0]}")
+                    print(f"    Response (Hex): {data.hex().upper()}")
+                    try:
+                        decoded = data.decode("utf-8")
+                        print(f"    Response (String): {decoded}")
+                    except Exception:
+                        pass
+        except Exception as e:
+            print(f"Error during discovery: {e}")
+        finally:
+            sock.close()
+            if has_upgraded:
+                upgraded_sock.close()
+        print("\n--- Local discovery finished. ---")
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, do_discover)
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -177,6 +253,43 @@ def parse_args():
     subcommand_parsers = parser.add_subparsers(
         title="Commands", dest="command", required=True
     )
+
+    # Add discover_local subcommand
+    discover_local_parser = subcommand_parsers.add_parser(
+        "discover_local",
+        help="Broadcast UDP discovery ping to find controllers on the local network",
+    )
+    discover_local_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Time to listen for responses (default: 5.0 seconds)",
+    )
+    discover_local_parser.set_defaults(func=None)
+
+    # Add request_fw_update subcommand
+    fw_update_parser = subcommand_parsers.add_parser(
+        "request_fw_update",
+        help="Trigger a firmware update on the controller, pointing to a specific URL",
+    )
+    fw_update_parser.add_argument(
+        "--lnk-update-url",
+        default="",
+        help="URL for LNK module firmware (e.g. http://10.10.38.83:8080/lnkfw/)",
+    )
+    fw_update_parser.add_argument(
+        "--unv-update-url",
+        default="",
+        help="URL for universal panel controller firmware (e.g. http://10.10.38.83:8080/rbfw/firmware.bin)",
+    )
+    fw_update_parser.set_defaults(func=None)
+
+    # Add get_fw_update_status subcommand
+    fw_status_parser = subcommand_parsers.add_parser(
+        "get_fw_update_status",
+        help="Query the current firmware update status on the controller",
+    )
+    fw_status_parser.set_defaults(func=None)
 
     # Add discover_cloud subcommand
     discover_parser = subcommand_parsers.add_parser(
@@ -249,12 +362,38 @@ async def main():
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
 
     async with aiohttp.ClientSession() as session:
-        if args.command == "discover_cloud":
+        if args.command == "discover_local":
+            await discover_local(args.timeout)
+            return
+
+        elif args.command == "discover_cloud":
             await discover_cloud(session, args.config_file)
             return
 
         elif args.command == "stream_cloud":
             await stream_cloud(session, args.config_file, args.satellite_id)
+            return
+
+        elif args.command == "request_fw_update":
+            host = os.environ["RAINBIRD_SERVER"]
+            password = os.environ["RAINBIRD_PASSWORD"]
+            controller = await async_client.create_controller(session, host, password)
+            result = await controller._local_client.request(
+                "requestFwUpdate",
+                {
+                    "lnk_update_url": args.lnk_update_url,
+                    "unv_update_url": args.unv_update_url,
+                },
+            )
+            print(result)
+            return
+
+        elif args.command == "get_fw_update_status":
+            host = os.environ["RAINBIRD_SERVER"]
+            password = os.environ["RAINBIRD_PASSWORD"]
+            controller = await async_client.create_controller(session, host, password)
+            result = await controller._local_client.request("getFwUpdateStatus")
+            print(result)
             return
 
         host = os.environ["RAINBIRD_SERVER"]

--- a/examples/rainbird_tool.py
+++ b/examples/rainbird_tool.py
@@ -24,7 +24,15 @@ from typing import Any
 import aiohttp
 
 from pyrainbird import async_client
-from pyrainbird.cloud import AsyncRainbirdCloudClient, AsyncRainbirdCloudStream
+from pyrainbird.cloud import (
+    AsyncRainbirdCloudClient,
+    AsyncRainbirdCloudStream,
+    ConnectionStatusEvent,
+    GenericCloudStreamEvent,
+    RainSensorStateEvent,
+    RssiStateEvent,
+    StationStateEvent,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -149,11 +157,26 @@ async def stream_cloud(
         )
 
         async for event in stream.listen():
-            print(
-                f"[{event.updated_at.isoformat()}] Satellite {event.satellite_id} ({event.device_uuid}) - "
-                f"State: {event.state}, Active Station: {event.active_station}, "
-                f"Remaining: {event.remain_seconds}s, Rain Delay: {event.rain_delay}"
-            )
+            prefix = f"[{event.updated_at.isoformat()}] Satellite {event.satellite_id} ({event.device_uuid}) -"
+            if isinstance(event, StationStateEvent):
+                print(
+                    f"{prefix} Station {event.zone} - Watering: {event.is_watering}, "
+                    f"Remaining: {event.remaining_seconds}s, Program: {event.program_number}"
+                )
+            elif isinstance(event, RainSensorStateEvent):
+                print(f"{prefix} Rain Sensor - Wet: {event.is_wet}")
+            elif isinstance(event, ConnectionStatusEvent):
+                print(
+                    f"{prefix} Connection - Connected: {event.is_connected}, "
+                    f"Active Station: {event.active_station}, "
+                    f"Remaining: {event.remaining_seconds}s, Rain Delay: {event.rain_delay}"
+                )
+            elif isinstance(event, RssiStateEvent):
+                print(f"{prefix} Signal - RSSI: {event.rssi}")
+            elif isinstance(event, GenericCloudStreamEvent):
+                print(
+                    f"{prefix} Generic - Key: {event.event_key}, Data: {event.raw_data}"
+                )
     except asyncio.CancelledError:
         print("Stream cancelled.")
     except Exception as err:

--- a/pyrainbird/cloud/__init__.py
+++ b/pyrainbird/cloud/__init__.py
@@ -5,7 +5,15 @@ from .client import (
     RainbirdCloudTokenProvider,
     async_authenticate_cloud,
 )
-from .stream import AsyncRainbirdCloudStream, CloudStreamEvent
+from .stream import (
+    AsyncRainbirdCloudStream,
+    CloudStreamEvent,
+    ConnectionStatusEvent,
+    GenericCloudStreamEvent,
+    RainSensorStateEvent,
+    RssiStateEvent,
+    StationStateEvent,
+)
 
 __all__ = [
     "AsyncRainbirdCloudClient",
@@ -13,4 +21,9 @@ __all__ = [
     "async_authenticate_cloud",
     "AsyncRainbirdCloudStream",
     "CloudStreamEvent",
+    "ConnectionStatusEvent",
+    "GenericCloudStreamEvent",
+    "RainSensorStateEvent",
+    "RssiStateEvent",
+    "StationStateEvent",
 ]

--- a/pyrainbird/cloud/stream.py
+++ b/pyrainbird/cloud/stream.py
@@ -67,15 +67,53 @@ BACKOFF_FACTOR = 2.0
 
 @dataclass
 class CloudStreamEvent:
-    """Represents a real-time status update from a cloud satellite."""
+    """Base class for real-time cloud satellite events."""
 
     satellite_id: int
     device_uuid: str
-    state: str
-    active_station: int | None
-    remain_seconds: int | None
-    rain_delay: int | None
     updated_at: datetime.datetime
+
+
+@dataclass
+class StationStateEvent(CloudStreamEvent):
+    """Fired when a specific zone/station starts or stops watering."""
+
+    zone: int
+    is_watering: bool
+    remaining_seconds: int | None
+    program_number: int | None
+
+
+@dataclass
+class RainSensorStateEvent(CloudStreamEvent):
+    """Fired when the rain sensor detects wet/dry status changes."""
+
+    is_wet: bool
+
+
+@dataclass
+class ConnectionStatusEvent(CloudStreamEvent):
+    """Fired with overall connection and active status details."""
+
+    is_connected: bool
+    active_station: int | None
+    remaining_seconds: int | None
+    rain_delay: int | None
+
+
+@dataclass
+class RssiStateEvent(CloudStreamEvent):
+    """Fired when device RSSI (signal strength) changes."""
+
+    rssi: int
+
+
+@dataclass
+class GenericCloudStreamEvent(CloudStreamEvent):
+    """Catch-all event for any unknown/new sort keys (future-proofing)."""
+
+    event_key: str
+    raw_data: str | None
 
 
 class AsyncRainbirdCloudStream:
@@ -130,52 +168,134 @@ class AsyncRainbirdCloudStream:
                 updated_at = datetime.datetime.now(datetime.timezone.utc)
 
             inner_data_str = device_state.get("Data")
-            active_station = None
-            remain_seconds = None
-            rain_delay = None
-            state = sk
 
-            if inner_data_str:
-                try:
-                    inner_data = json.loads(inner_data_str)
-                    if isinstance(inner_data, dict):
-                        active_station = inner_data.get("activeStation")
-                        remain_seconds = inner_data.get("remainSec")
-                        rain_delay = inner_data.get("rainDelay")
-                        if "state" in inner_data:
-                            state = str(inner_data["state"])
-                    elif inner_data is not None:
-                        state = str(inner_data)
-                except json.JSONDecodeError as err:
-                    _LOGGER.warning("Failed to parse inner state data JSON: %s", err)
+            # Route parsing based on Sort Key (SK) type
+            if sk == "RSSI":
+                rssi_val = 0
+                if inner_data_str:
+                    try:
+                        rssi_val = int(inner_data_str)
+                    except ValueError:
+                        pass
+                return RssiStateEvent(
+                    satellite_id=self._satellite_id,
+                    device_uuid=device_uuid,
+                    updated_at=updated_at,
+                    rssi=rssi_val,
+                )
 
-            if sk.startswith("Station") and active_station is None:
+            elif sk == "Event#RainSensorState":
+                is_wet = False
+                if inner_data_str:
+                    try:
+                        inner_data = json.loads(inner_data_str)
+                        if isinstance(inner_data, dict):
+                            is_wet = str(inner_data.get("state")) == "1"
+                        else:
+                            is_wet = str(inner_data) == "1"
+                    except Exception:
+                        pass
+                return RainSensorStateEvent(
+                    satellite_id=self._satellite_id,
+                    device_uuid=device_uuid,
+                    updated_at=updated_at,
+                    is_wet=is_wet,
+                )
+
+            elif sk.startswith("Station"):
                 try:
-                    active_station = int(sk[7:])
+                    zone_num = int(sk[7:])
                 except ValueError:
-                    pass
+                    return None
 
-            # If remain_seconds is a Unix epoch timestamp, calculate relative remaining seconds
-            if (
-                remain_seconds is not None
-                and remain_seconds > 1000000000
-                and timestamp_val
-            ):
-                try:
-                    server_ts = int(timestamp_val)
-                    if remain_seconds >= server_ts:
-                        remain_seconds -= server_ts
-                except (ValueError, TypeError):
-                    pass
+                is_watering = False
+                remain_seconds = None
+                program_number = None
 
-            return CloudStreamEvent(
+                if inner_data_str:
+                    try:
+                        inner_data = json.loads(inner_data_str)
+                        if isinstance(inner_data, dict):
+                            is_watering = str(inner_data.get("state")) == "1"
+                            remain_seconds = inner_data.get("remainSec")
+                            program_number = inner_data.get("programNumber")
+                    except Exception:
+                        pass
+
+                # If remain_seconds is an epoch timestamp, convert to relative duration
+                if (
+                    remain_seconds is not None
+                    and remain_seconds > 1000000000
+                    and timestamp_val
+                ):
+                    try:
+                        server_ts = int(timestamp_val)
+                        if remain_seconds >= server_ts:
+                            remain_seconds -= server_ts
+                    except (ValueError, TypeError):
+                        pass
+
+                return StationStateEvent(
+                    satellite_id=self._satellite_id,
+                    device_uuid=device_uuid,
+                    updated_at=updated_at,
+                    zone=zone_num,
+                    is_watering=is_watering,
+                    remaining_seconds=remain_seconds,
+                    program_number=program_number,
+                )
+
+            elif sk == "Connected":
+                is_connected = True
+                active_station = None
+                remain_seconds = None
+                rain_delay = None
+
+                if inner_data_str:
+                    try:
+                        inner_data = json.loads(inner_data_str)
+                        if isinstance(inner_data, dict):
+                            active_station = inner_data.get("activeStation")
+                            remain_seconds = inner_data.get("remainSec")
+                            rain_delay = inner_data.get("rainDelay")
+                            if str(inner_data.get("state")) in ("0", "offline"):
+                                is_connected = False
+                        else:
+                            if str(inner_data) in ("0", "offline"):
+                                is_connected = False
+                    except Exception:
+                        pass
+
+                # Epoch check for remaining seconds
+                if (
+                    remain_seconds is not None
+                    and remain_seconds > 1000000000
+                    and timestamp_val
+                ):
+                    try:
+                        server_ts = int(timestamp_val)
+                        if remain_seconds >= server_ts:
+                            remain_seconds -= server_ts
+                    except (ValueError, TypeError):
+                        pass
+
+                return ConnectionStatusEvent(
+                    satellite_id=self._satellite_id,
+                    device_uuid=device_uuid,
+                    updated_at=updated_at,
+                    is_connected=is_connected,
+                    active_station=active_station,
+                    remaining_seconds=remain_seconds,
+                    rain_delay=rain_delay,
+                )
+
+            # Fallback for unrecognized sort keys (future proofing)
+            return GenericCloudStreamEvent(
                 satellite_id=self._satellite_id,
                 device_uuid=device_uuid,
-                state=state,
-                active_station=active_station,
-                remain_seconds=remain_seconds,
-                rain_delay=rain_delay,
                 updated_at=updated_at,
+                event_key=sk,
+                raw_data=inner_data_str,
             )
         except Exception as e:
             _LOGGER.error("Error parsing stream event: %s", e)

--- a/pyrainbird/data.py
+++ b/pyrainbird/data.py
@@ -165,6 +165,21 @@ class States:
             result += ("%d:%d" % (i + 1, 1 if self.states[i] else 0),)
         return "states: %s" % ", ".join(result)
 
+    def update_zone(self, zone: int, active: bool) -> "States":
+        """Return a new States instance with the specified zone state updated."""
+        new_states = list(self.states)
+        while len(new_states) < zone:
+            new_states.append(False)
+        new_states[zone - 1] = active
+
+        # Recompute mask bytes in groups of 8 states
+        mask_bytes = []
+        for i in range(0, len(new_states), 8):
+            chunk = new_states[i : i + 8]
+            byte_val = sum((1 << j) for j, val in enumerate(chunk) if val)
+            mask_bytes.append(f"{byte_val:02X}")
+        return States("".join(mask_bytes))
+
 
 @dataclass
 class AvailableStations:

--- a/pyrainbird/fake/__init__.py
+++ b/pyrainbird/fake/__init__.py
@@ -1,0 +1,9 @@
+"""Simulated Rain Bird controller and stick server for testing and firmware capture."""
+
+from .device import FakeRainbirdDevice
+from .server import RainbirdFakeServer
+
+__all__ = [
+    "FakeRainbirdDevice",
+    "RainbirdFakeServer",
+]

--- a/pyrainbird/fake/__main__.py
+++ b/pyrainbird/fake/__main__.py
@@ -1,0 +1,93 @@
+"""Command Line Interface for running the fake Rain Bird server."""
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from pyrainbird.fake.server import RainbirdFakeServer
+
+# Configure basic logging to stdout
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+
+_LOGGER = logging.getLogger("pyrainbird.fake")
+
+
+async def main() -> None:
+    """Parse command line arguments and run the fake server."""
+    parser = argparse.ArgumentParser(
+        description="Run a fake Rain Bird device server for local testing and firmware extraction."
+    )
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="IP address to bind the servers to (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="TCP port for the HTTP stick server (default: 8080, note: real controllers use 80)",
+    )
+    parser.add_argument(
+        "--udp-port",
+        type=int,
+        default=33667,
+        help="UDP port for the discovery server (default: 33667)",
+    )
+    parser.add_argument(
+        "--mac",
+        default="44:2c:05:00:11:22",
+        help="MAC address to return in Legacy discovery mode (default: 44:2c:05:00:11:22)",
+    )
+    parser.add_argument(
+        "--uuid",
+        default="123e4567-e89b-12d3-a456-426614174000",
+        help="UUID to return in Upgraded discovery mode (default: 123e4567-e89b-12d3-a456-426614174000)",
+    )
+    parser.add_argument(
+        "--password",
+        default=None,
+        help="Optional controller password/PIN. If set, payloads must be encrypted.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./extracted_fw",
+        help="Directory to save downloaded firmware files (default: ./extracted_fw)",
+    )
+
+    args = parser.parse_args()
+
+    server = RainbirdFakeServer(
+        mac_address=args.mac,
+        uuid_str=args.uuid,
+        password=args.password,
+        host=args.host,
+        port=args.port,
+        udp_port=args.udp_port,
+        output_dir=args.output_dir,
+    )
+
+    await server.start()
+    _LOGGER.info("Fake Rain Bird server is running. Press Ctrl+C to stop.")
+
+    try:
+        # Keep running until interrupted
+        while True:
+            await asyncio.sleep(3600)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        _LOGGER.info("Stopping fake server...")
+    finally:
+        await server.stop()
+        _LOGGER.info("Server stopped.")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/pyrainbird/fake/device.py
+++ b/pyrainbird/fake/device.py
@@ -1,0 +1,370 @@
+"""Stateful Fake Rain Bird Device Simulator."""
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import date, time
+from typing import Any
+
+import aiohttp
+
+from pyrainbird import rainbird
+from pyrainbird.encryption import decrypt, encrypt
+from pyrainbird.resources import MODEL_INFO, RAINBIRD_COMMANDS
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class LogEntry:
+    """Base class for log entries."""
+
+    pass
+
+
+@dataclass
+class RequestLogEntry(LogEntry):
+    """A logged outgoing JSON-RPC request."""
+
+    request: dict[str, Any]
+    command: str | None = None
+    raw_data: str | None = None
+
+    def __str__(self) -> str:
+        lines = ["[client >]"]
+        if self.command:
+            lines.append(f"Intent: {self.command} ({self.raw_data})")
+        lines.append(f"Payload: {json.dumps(self.request, indent=2)}")
+        return "\n".join(lines)
+
+
+@dataclass
+class ResponseLogEntry(LogEntry):
+    """A logged incoming JSON-RPC response."""
+
+    response: dict[str, Any]
+
+    def __str__(self) -> str:
+        lines = ["[server <]"]
+        lines.append(f"Payload: {json.dumps(self.response, indent=2)}")
+        return "\n".join(lines)
+
+
+@dataclass
+class ErrorLogEntry(LogEntry):
+    """A completely failed or malformed intercept log."""
+
+    error: str
+    reason: str
+
+    def __str__(self) -> str:
+        lines = ["[error !]"]
+        lines.append(f"{self.error}: {self.reason}")
+        return "\n".join(lines)
+
+
+class CapturedRequestLog(list[LogEntry]):
+    """List of captured intercepted API requests."""
+
+    def __str__(self) -> str:
+        """Format the log as a sequential string."""
+        return "\n\n".join(str(entry) for entry in self).strip()
+
+
+class FakeRainbirdDevice:
+    """Stateful fake Rain Bird device simulator."""
+
+    def __init__(self, output_dir: str = "./extracted_fw") -> None:
+        self.request_log = CapturedRequestLog()
+        self.output_dir = output_dir
+
+        # Device State variables
+        self.model_code = 0x07  # Default to ESP-TM2
+        self.version_major = 1
+        self.version_minor = 3
+
+        self.stations: set[int] = {1, 2, 3, 4, 5, 6, 7}
+        self.schedule: dict[str, str] = {}
+        self.zone_states: dict[str, str] = {}
+
+        self.serial_number: int = 0x12635436566
+        self.time: time = time(12, 34, 56)
+        self.date: date = date(2023, 1, 1)
+        self.water_budget_pct: int = 100
+        self.rain_sensor_state: bool = False
+        self.rain_delay: int = 0
+        self.irrigation_state: bool = False
+
+        # Firmware Update State variables (0 = OK, 1 = Error, 2 = Busy)
+        self.update_status = 0
+        self.lnk_progress = 0
+        self.unv_progress = 0
+        self._update_task: asyncio.Task[None] | None = None
+
+        # Command handlers
+        self.handlers = {
+            "02": self._handle_model_and_version,
+            "03": self._handle_available_stations,
+            "05": self._handle_serial_number,
+            "10": self._handle_current_time,
+            "12": self._handle_current_date,
+            "20": self._handle_retrieve_schedule,
+            "30": self._handle_water_budget,
+            "36": self._handle_rain_delay,
+            "3E": self._handle_rain_sensor,
+            "3F": self._handle_zone_state,
+            "48": self._handle_current_irrigation,
+            # Setters reply with ACK
+            "11": self._handle_ack,
+            "13": self._handle_ack,
+            "37": self._handle_ack,
+            "38": self._handle_ack,
+            "39": self._handle_ack,
+            "3A": self._handle_ack,
+            "40": self._handle_ack,
+            "42": self._handle_ack,
+        }
+
+    def _handle_model_and_version(self, data: str) -> str:
+        """Handle ModelAndVersionRequest (02)."""
+        return (
+            f"82{self.model_code:04X}{self.version_major:02X}{self.version_minor:02X}"
+        )
+
+    def _handle_available_stations(self, data: str) -> str:
+        """Handle AvailableStationsRequest (03)."""
+        page = int(data[2:4], 16) if len(data) >= 4 else 0
+        mask_str = ""
+        # 4 bytes per page (32 stations)
+        for b in range(4):
+            byte_val = 0
+            for bit in range(8):
+                station_num = page * 32 + b * 8 + bit + 1
+                if station_num in self.stations:
+                    byte_val |= 1 << bit
+            mask_str += f"{byte_val:02X}"
+        return f"83{page:02X}{mask_str}"
+
+    def _handle_retrieve_schedule(self, data: str) -> str:
+        """Handle RetrieveScheduleRequest (20)."""
+        subcommand = data[2:6] if len(data) >= 6 else data[2:]
+        return self.schedule.get(subcommand, "80" + subcommand + "00000000")
+
+    def _handle_zone_state(self, data: str) -> str:
+        """Handle RequestZoneState (3F)."""
+        subcommand = data[2:4] if len(data) >= 4 else data[2:]
+        return self.zone_states.get(subcommand, "BF" + subcommand + "00000000")
+
+    def _encode(self, cmd: str, *args: Any) -> str:
+        cmd_set = RAINBIRD_COMMANDS.get(cmd) or next(
+            v for v in RAINBIRD_COMMANDS.values() if v.get("command") == cmd
+        )
+        return rainbird.encode_command(cmd_set, *args)
+
+    def _handle_ack(self, data: str) -> str:
+        return self._encode("AcknowledgeResponse", int(data[:2], 16))
+
+    def _handle_serial_number(self, data: str) -> str:
+        return self._encode("SerialNumberResponse", self.serial_number)
+
+    def _handle_current_time(self, data: str) -> str:
+        return self._encode(
+            "CurrentTimeResponse", self.time.hour, self.time.minute, self.time.second
+        )
+
+    def _handle_current_date(self, data: str) -> str:
+        return self._encode(
+            "CurrentDateResponse", self.date.day, self.date.month, self.date.year
+        )
+
+    def _handle_water_budget(self, data: str) -> str:
+        return self._encode("WaterBudgetResponse", 1, self.water_budget_pct)
+
+    def _handle_rain_sensor(self, data: str) -> str:
+        return self._encode("CurrentRainSensorStateResponse", self.rain_sensor_state)
+
+    def _handle_rain_delay(self, data: str) -> str:
+        return self._encode("RainDelaySettingResponse", self.rain_delay)
+
+    def _handle_current_irrigation(self, data: str) -> str:
+        return self._encode("CurrentIrrigationStateResponse", self.irrigation_state)
+
+    def set_model(self, model_identifier: str) -> None:
+        """Lookup and set the model code from pyrainbird's device registry."""
+        for info in MODEL_INFO:
+            if (
+                info.get("code") == model_identifier
+                or info.get("name") == model_identifier
+            ):
+                self.model_code = int(info["device_id"], 16)
+                return
+        raise ValueError(
+            f"Unknown model identifier '{model_identifier}' in models.yaml registry."
+        )
+
+    def process_request(self, body: bytes, pwd: str | None) -> dict[str, Any] | None:
+        """Decode and log a request, returning the decoded JSON."""
+        try:
+            if pwd:
+                decrypted_req = (
+                    decrypt(body, pwd)
+                    .decode("UTF-8")
+                    .rstrip("\x10")
+                    .rstrip("\x0a")
+                    .rstrip("\x00")
+                    .rstrip()
+                )
+                decoded_request = json.loads(decrypted_req)
+            else:
+                decoded_request = json.loads(body.decode("UTF-8"))
+
+            log_entry = RequestLogEntry(request=decoded_request)
+
+            if (
+                decoded_request.get("method") == "tunnelSip"
+                and "params" in decoded_request
+            ):
+                data = decoded_request["params"].get("data")
+                if data and len(data) >= 2:
+                    cmd_code = data[:2]
+                    command_name = "Unknown"
+                    for name, cmd_set in RAINBIRD_COMMANDS.items():
+                        if cmd_set.get("command") == cmd_code:
+                            command_name = name
+                            break
+                    log_entry.command = command_name
+                    log_entry.raw_data = data
+
+            self.request_log.append(log_entry)
+            return decoded_request
+        except Exception as e:
+            self.request_log.append(ErrorLogEntry("Failed to decode request", str(e)))
+            _LOGGER.exception("Failed to decode request")
+            return None
+
+    def generate_response(
+        self, request: dict[str, Any], pwd: str | None
+    ) -> bytes | None:
+        """Autonomously generate a response for a decoded request. If unsupported, return None."""
+        if request.get("method") != "tunnelSip" or "params" not in request:
+            return None
+
+        data = request["params"].get("data")
+        if not data:
+            return None
+
+        req_id = request.get("id", 1)
+        cmd_code = data[:2]
+        handler = self.handlers.get(cmd_code)
+
+        if handler:
+            resp_hex = handler(data)
+            payload = json.dumps(
+                {"jsonrpc": "2.0", "result": {"data": resp_hex}, "id": req_id}
+            )
+            if pwd:
+                return encrypt(payload, pwd)
+            return payload.encode("UTF-8")
+
+        return None
+
+    def generate_nack(self, request: dict[str, Any], pwd: str | None) -> bytes:
+        """Autonomously generate a NotAcknowledgeResponse for an unsupported command."""
+        req_id = request.get("id", 1)
+        data = request.get("params", {}).get("data", "00")
+
+        command_echo = data[:2] if len(data) >= 2 else "00"
+        nak_code = "00"  # generic NAK
+        resp_hex = f"00{command_echo}{nak_code}"
+
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "result": {"data": resp_hex}, "id": req_id}
+        )
+        if pwd:
+            return encrypt(payload, pwd)
+        return payload.encode("UTF-8")
+
+    async def start_firmware_update(self, update_url: str) -> None:
+        """Trigger an asynchronous firmware update download task."""
+        # Cancel any previous task
+        if self._update_task and not self._update_task.done():
+            self._update_task.cancel()
+
+        self._update_task = asyncio.create_task(
+            self._firmware_update_runner(update_url)
+        )
+
+    async def _firmware_update_runner(self, update_url: str) -> None:
+        _LOGGER.info("Starting simulated firmware update from URL: %s", update_url)
+        self.update_status = 2  # Busy
+        self.lnk_progress = 0
+        self.unv_progress = 0
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                if update_url.endswith("/"):
+                    # LNK update: download release.json and filesystem.bin
+                    files_to_download = ["release.json", "filesystem.bin"]
+                    base_url = update_url
+                else:
+                    # Controller update: download direct firmware.bin
+                    files_to_download = [os.path.basename(update_url)]
+                    base_url = os.path.dirname(update_url) + "/"
+
+                total_files = len(files_to_download)
+                os.makedirs(self.output_dir, exist_ok=True)
+
+                for idx, filename in enumerate(files_to_download):
+                    file_url = f"{base_url}{filename}"
+                    _LOGGER.info("Downloading %s from %s...", filename, file_url)
+
+                    async with session.get(file_url) as resp:
+                        if resp.status != 200:
+                            raise RuntimeError(
+                                f"HTTP status {resp.status} for {filename}"
+                            )
+
+                        dest_path = os.path.join(self.output_dir, filename)
+                        with open(dest_path, "wb") as f:
+                            chunk_size = 4096
+                            downloaded = 0
+                            content_length = resp.content_length or 102400
+
+                            async for chunk in resp.content.iter_chunked(chunk_size):
+                                f.write(chunk)
+                                downloaded += len(chunk)
+
+                                progress = int((downloaded / content_length) * 100)
+                                progress = min(100, max(0, progress))
+
+                                file_weight = 1.0 / total_files
+                                current_overall_progress = int(
+                                    (
+                                        idx * file_weight
+                                        + (progress / 100.0) * file_weight
+                                    )
+                                    * 100
+                                )
+                                self.lnk_progress = current_overall_progress
+                                self.unv_progress = current_overall_progress
+                                await asyncio.sleep(0.01)
+
+                _LOGGER.info(
+                    "Successfully downloaded all firmware files to %s", self.output_dir
+                )
+                self.update_status = 0  # OK
+                self.lnk_progress = 100
+                self.unv_progress = 100
+        except Exception as e:
+            _LOGGER.exception("Error during firmware update download: %s", e)
+            self.update_status = 1  # Error
+
+    def get_firmware_update_status(self) -> dict[str, int]:
+        """Return the current firmware update status payload."""
+        return {
+            "updateStatus": self.update_status,
+            "lnkProgress": self.lnk_progress,
+            "unvProgress": self.unv_progress,
+        }

--- a/pyrainbird/fake/server.py
+++ b/pyrainbird/fake/server.py
@@ -1,0 +1,201 @@
+"""Async UDP and HTTP Server for Simulated Rain Bird Device."""
+
+import asyncio
+import json
+import logging
+
+from aiohttp import web
+
+from pyrainbird.encryption import encrypt
+from .device import FakeRainbirdDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RainbirdUDPDiscoveryProtocol(asyncio.DatagramProtocol):
+    """Protocol to handle UDP discovery broadcasts."""
+
+    def __init__(
+        self, mac_address: str, uuid_str: str, response_udp_port: int = 33668
+    ) -> None:
+        self.mac_address = mac_address
+        self.uuid_str = uuid_str
+        self.response_udp_port = response_udp_port
+        self.transport: asyncio.DatagramTransport | None = None
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        self.transport = transport  # type: ignore[assignment]
+
+    def datagram_received(self, data: bytes, addr: tuple[str, int]) -> None:
+        try:
+            message = data.decode("utf-8", errors="ignore").strip()
+            if "RBD-ANDROID" in message:
+                _LOGGER.info("Received UDP discovery ping from %s: %s", addr, message)
+
+                # 1. Legacy Response: MAC address string to ephemeral sender port
+                mac_hex = self.mac_address.replace(":", "").replace("-", "").lower()
+                if self.transport:
+                    self.transport.sendto(mac_hex.encode("utf-8"), addr)
+                    _LOGGER.info("Sent legacy response to %s: %s", addr, mac_hex)
+
+                    # 2. Upgraded Response: UUID string to port response_udp_port of sender's IP
+                    self.transport.sendto(
+                        self.uuid_str.encode("utf-8"), (addr[0], self.response_udp_port)
+                    )
+                    _LOGGER.info(
+                        "Sent upgraded response to %s:%d: %s",
+                        addr[0],
+                        self.response_udp_port,
+                        self.uuid_str,
+                    )
+        except Exception as e:
+            _LOGGER.exception("Error in UDP discovery handler: %s", e)
+
+
+class RainbirdFakeServer:
+    """Combines UDP discovery and HTTP stick JSON-RPC servers."""
+
+    def __init__(
+        self,
+        mac_address: str = "44:2c:05:00:11:22",
+        uuid_str: str = "123e4567-e89b-12d3-a456-426614174000",
+        password: str | None = None,
+        host: str = "0.0.0.0",
+        port: int = 80,
+        udp_port: int = 33667,
+        response_udp_port: int = 33668,
+        output_dir: str = "./extracted_fw",
+    ) -> None:
+        self.mac_address = mac_address
+        self.uuid_str = uuid_str
+        self.password = password
+        self.host = host
+        self.port = port
+        self.udp_port = udp_port
+        self.response_udp_port = response_udp_port
+        self.output_dir = output_dir
+
+        self.device = FakeRainbirdDevice(output_dir=output_dir)
+        self.device.set_model("ESP-TM2")  # default
+
+        self._udp_transport: asyncio.DatagramTransport | None = None
+        self._http_runner: web.AppRunner | None = None
+        self._http_site: web.TCPSite | None = None
+
+    async def start(self) -> None:
+        """Start both UDP discovery and HTTP stick server."""
+        # 1. UDP Discovery Server
+        loop = asyncio.get_running_loop()
+        _LOGGER.info(
+            "Starting UDP Discovery Server on %s:%d...", self.host, self.udp_port
+        )
+
+        # Set socket options for broadcast / address reuse
+        try:
+            self._udp_transport, _ = await loop.create_datagram_endpoint(
+                lambda: RainbirdUDPDiscoveryProtocol(
+                    self.mac_address, self.uuid_str, self.response_udp_port
+                ),
+                local_addr=(self.host, self.udp_port),
+                allow_broadcast=True,
+            )
+        except Exception as e:
+            _LOGGER.error("Failed to start UDP Discovery Server: %s", e)
+
+        # 2. HTTP Web Server
+        _LOGGER.info("Starting HTTP Stick Server on %s:%d...", self.host, self.port)
+        app = web.Application()
+        app["password"] = self.password
+        app["device"] = self.device
+
+        app.router.add_post("/stick", self._handle_stick)
+        app.router.add_post("/stick:80", self._handle_stick)
+
+        self._http_runner = web.AppRunner(app)
+        await self._http_runner.setup()
+        self._http_site = web.TCPSite(self._http_runner, self.host, self.port)
+        await self._http_site.start()
+
+    async def stop(self) -> None:
+        """Stop both servers."""
+        if self._udp_transport:
+            self._udp_transport.close()
+            self._udp_transport = None
+            _LOGGER.info("Stopped UDP Discovery Server.")
+
+        if self._http_site:
+            await self._http_site.stop()
+            self._http_site = None
+        if self._http_runner:
+            await self._http_runner.cleanup()
+            self._http_runner = None
+            _LOGGER.info("Stopped HTTP Stick Server.")
+
+    async def _handle_stick(self, request: web.Request) -> web.Response:
+        """Handle JSON-RPC requests sent to the stick endpoint."""
+        body = await request.read()
+        pwd = request.app["password"]
+        device = request.app["device"]
+
+        # Parse JSON-RPC
+        decoded_request = device.process_request(body, pwd)
+        if not decoded_request:
+            try:
+                decoded_request = json.loads(body.decode("utf-8"))
+            except Exception:
+                return web.Response(
+                    status=400, text="Bad Request: Decryption or JSON parsing failed"
+                )
+
+        method = decoded_request.get("method")
+        req_id = decoded_request.get("id", 1)
+
+        _LOGGER.info("Handling RPC method: %s", method)
+
+        if method == "requestFwUpdate":
+            params = decoded_request.get("params", {})
+            lnk_update_url = params.get("lnk_update_url")
+            unv_update_url = params.get("unv_update_url")
+            update_url = lnk_update_url or unv_update_url
+
+            if update_url:
+                await device.start_firmware_update(update_url)
+
+            # Response payload for requestFwUpdate trigger success
+            response_data = {
+                "jsonrpc": "2.0",
+                "result": {"status": "OK"},
+                "id": req_id,
+            }
+
+        elif method == "getFwUpdateStatus":
+            result = device.get_firmware_update_status()
+            response_data = {
+                "jsonrpc": "2.0",
+                "result": result,
+                "id": req_id,
+            }
+
+        else:
+            # Handle standard SIP tunnel / command requests
+            resp_bytes = device.generate_response(decoded_request, pwd)
+            if resp_bytes is not None:
+                return web.Response(
+                    body=resp_bytes, content_type="application/octet-stream"
+                )
+
+            # Fallback for unhandled methods to prevent app crash
+            response_data = {
+                "jsonrpc": "2.0",
+                "result": {},
+                "id": req_id,
+            }
+
+        # Format and encrypt if password set
+        if pwd:
+            payload_bytes = encrypt(json.dumps(response_data), pwd)
+            return web.Response(
+                body=payload_bytes, content_type="application/octet-stream"
+            )
+
+        return web.json_response(response_data)

--- a/tests/__snapshots__/test_cloud_stream.ambr
+++ b/tests/__snapshots__/test_cloud_stream.ambr
@@ -1,16 +1,16 @@
 # serializer version: 1
 # name: test_parse_event_snapshot[scalar_int]
-  CloudStreamEvent(satellite_id=527302, device_uuid='7b1ad1ef-91df-4e50-9004-269c139c681c', state='0', active_station=None, remain_seconds=None, rain_delay=None, updated_at=datetime.datetime(2026, 6, 13, 23, 18, tzinfo=datetime.timezone.utc))
+  ConnectionStatusEvent(satellite_id=527302, device_uuid='7b1ad1ef-91df-4e50-9004-269c139c681c', updated_at=datetime.datetime(2026, 6, 13, 23, 18, tzinfo=datetime.timezone.utc), is_connected=False, active_station=None, remaining_seconds=None, rain_delay=None)
 # ---
 # name: test_parse_event_snapshot[scalar_str]
-  CloudStreamEvent(satellite_id=527302, device_uuid='7b1ad1ef-91df-4e50-9004-269c139c681c', state='offline', active_station=None, remain_seconds=None, rain_delay=None, updated_at=datetime.datetime(2026, 6, 13, 23, 18, tzinfo=datetime.timezone.utc))
+  ConnectionStatusEvent(satellite_id=527302, device_uuid='7b1ad1ef-91df-4e50-9004-269c139c681c', updated_at=datetime.datetime(2026, 6, 13, 23, 18, tzinfo=datetime.timezone.utc), is_connected=False, active_station=None, remaining_seconds=None, rain_delay=None)
 # ---
 # name: test_parse_event_snapshot[station_epoch_timestamp]
-  CloudStreamEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', state='1', active_station=1, remain_seconds=88, rain_delay=None, updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc))
+  StationStateEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc), zone=1, is_watering=True, remaining_seconds=88, program_number=34)
 # ---
 # name: test_parse_event_snapshot[station_normal_duration]
-  CloudStreamEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', state='1', active_station=2, remain_seconds=88, rain_delay=None, updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc))
+  StationStateEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc), zone=2, is_watering=True, remaining_seconds=88, program_number=36)
 # ---
 # name: test_parse_event_snapshot[station_past_epoch_timestamp]
-  CloudStreamEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', state='1', active_station=1, remain_seconds=1476535243, rain_delay=None, updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc))
+  StationStateEvent(satellite_id=527302, device_uuid='8c756129-0000-8da0-9049-8e44b2deb091', updated_at=datetime.datetime(2026, 6, 14, 20, 22, 12, tzinfo=datetime.timezone.utc), zone=1, is_watering=True, remaining_seconds=1476535243, program_number=34)
 # ---

--- a/tests/test_cloud_stream.py
+++ b/tests/test_cloud_stream.py
@@ -15,7 +15,14 @@ import pytest
 from aiohttp.test_utils import TestClient
 
 from pyrainbird.async_client import RainbirdTokenProvider
-from pyrainbird.cloud.stream import AsyncRainbirdCloudStream
+from pyrainbird.cloud.stream import (
+    AsyncRainbirdCloudStream,
+    ConnectionStatusEvent,
+    GenericCloudStreamEvent,
+    RainSensorStateEvent,
+    RssiStateEvent,
+    StationStateEvent,
+)
 from pyrainbird.exceptions import RainbirdAuthException
 
 
@@ -218,11 +225,12 @@ async def test_stream_success(
 
         # Verify first event
         ev1 = events[0]
+        assert isinstance(ev1, ConnectionStatusEvent)
         assert ev1.satellite_id == 527302
         assert ev1.device_uuid == "7b1ad1ef-91df-4e50-9004-269c139c681c"
-        assert ev1.state == "Connected"
+        assert ev1.is_connected is True
         assert ev1.active_station == 2
-        assert ev1.remain_seconds == 300
+        assert ev1.remaining_seconds == 300
         assert ev1.rain_delay == 1
         assert ev1.updated_at == datetime.datetime(
             2026, 6, 13, 23, 18, tzinfo=datetime.timezone.utc
@@ -230,9 +238,11 @@ async def test_stream_success(
 
         # Verify second event
         ev2 = events[1]
+        assert isinstance(ev2, ConnectionStatusEvent)
         assert ev2.device_uuid == "7b1ad1ef-91df-4e50-9004-269c139c681c"
+        assert ev2.is_connected is True
         assert ev2.active_station is None
-        assert ev2.remain_seconds == 0
+        assert ev2.remaining_seconds == 0
         assert ev2.rain_delay == 0
 
 
@@ -367,3 +377,120 @@ def test_parse_event_snapshot(json_path: str, snapshot: Any) -> None:
     assert event is not None
 
     assert event == snapshot
+
+
+def test_parse_event_types() -> None:
+    """Test that _parse_event correctly routes and parses different AppSync messages."""
+    stream = AsyncRainbirdCloudStream(
+        MockTokenProvider(), 527302, "7b1ad1ef-91df-4e50-9004-269c139c681c", None
+    )  # type: ignore
+
+    # 1. RSSI
+    rssi_raw = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "RSSI",
+                    "Data": "-82",
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    ev = stream._parse_event(rssi_raw)
+    assert isinstance(ev, RssiStateEvent)
+    assert ev.rssi == -82
+
+    # 2. RainSensorStateEvent (wet)
+    sensor_wet_raw = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "Event#RainSensorState",
+                    "Data": '{"state":1}',
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    ev = stream._parse_event(sensor_wet_raw)
+    assert isinstance(ev, RainSensorStateEvent)
+    assert ev.is_wet is True
+
+    # 3. RainSensorStateEvent (dry)
+    sensor_dry_raw = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "Event#RainSensorState",
+                    "Data": '{"state":0}',
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    ev = stream._parse_event(sensor_dry_raw)
+    assert isinstance(ev, RainSensorStateEvent)
+    assert ev.is_wet is False
+
+    # 4. StationStateEvent (watering)
+    station_on_raw = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "Station3",
+                    "Data": '{"state":1,"remainSec":1781393280,"programNumber":36}',
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    ev = stream._parse_event(station_on_raw)
+    assert isinstance(ev, StationStateEvent)
+    assert ev.zone == 3
+    assert ev.is_watering is True
+    # remaining_seconds should be adjusted by timestamp (1781393280 - 1781392680 = 600)
+    assert ev.remaining_seconds == 600
+    assert ev.program_number == 36
+
+    # 5. StationStateEvent (stopped)
+    station_off_raw = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "Station3",
+                    "Data": '{"state":-1,"remainSec":0,"programNumber":36}',
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    ev = stream._parse_event(station_off_raw)
+    assert isinstance(ev, StationStateEvent)
+    assert ev.zone == 3
+    assert ev.is_watering is False
+    assert ev.remaining_seconds == 0
+    assert ev.program_number == 36
+
+    # 6. GenericCloudStreamEvent
+    generic_raw = {
+        "payload": {
+            "data": {
+                "onUpdateDeviceStateTable": {
+                    "PK": "7b1ad1ef-91df-4e50-9004-269c139c681c",
+                    "SK": "UnknownKey",
+                    "Data": '{"foo":"bar"}',
+                    "TimeStamp": 1781392680,
+                }
+            }
+        }
+    }
+    ev = stream._parse_event(generic_raw)
+    assert isinstance(ev, GenericCloudStreamEvent)
+    assert ev.event_key == "UnknownKey"
+    assert ev.raw_data == '{"foo":"bar"}'

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -57,6 +57,37 @@ class TestSequence(unittest.TestCase):
             assert active == bit
             i = i + 1
 
+    def test_update_zone(self):
+        states = States("0000")
+        assert not any(states.states)
+
+        # Turn zone 2 on
+        states2 = states.update_zone(2, True)
+        assert states2.active(2) is True
+        assert states2.active_set == {2}
+        assert states2.states[1] is True
+        assert states2.states[:8] == (
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        )
+
+        # Turn zone 2 off
+        states3 = states2.update_zone(2, False)
+        assert states3.active(2) is False
+        assert states3.active_set == set()
+
+        # Turn zone 9 on (across byte boundary)
+        states4 = states.update_zone(9, True)
+        assert states4.active(9) is True
+        assert states4.active_set == {9}
+        assert states4.states[8] is True
+
 
 @pytest.mark.parametrize(
     ("response", "expected_name"),

--- a/tests/test_fake_server.py
+++ b/tests/test_fake_server.py
@@ -1,0 +1,156 @@
+"""Tests for the fake Rain Bird server."""
+
+import asyncio
+import json
+import socket
+import tempfile
+import pytest
+import aiohttp
+from aiohttp import web
+
+from pyrainbird.fake.server import RainbirdFakeServer
+
+
+@pytest.mark.asyncio
+async def test_fake_server_lifecycle_and_discovery() -> None:
+    """Test starting, stopping, discovering, and querying the fake server."""
+    # Find a free port for the upgraded response UDP listener
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    resp_udp_port = sock.getsockname()[1]
+    sock.close()
+
+    # Create temporary directory for downloads
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Start fake server with random ports (port=0, udp_port=0)
+        server = RainbirdFakeServer(
+            mac_address="00:11:22:33:44:55",
+            uuid_str="test-uuid-12345",
+            password=None,
+            host="127.0.0.1",
+            port=0,
+            udp_port=0,
+            response_udp_port=resp_udp_port,
+            output_dir=tmpdir,
+        )
+
+        await server.start()
+
+        try:
+            # 1. Resolve actual ports
+            http_port = server._http_runner.addresses[0][1]
+            udp_port = server._udp_transport.get_extra_info("sockname")[1]
+
+            # 2. Test UDP Discovery (Legacy mode)
+            # Send RBD-ANDROID to UDP discovery port
+            client_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            client_sock.settimeout(1.0)
+            client_sock.sendto(b"RBD-ANDROID", ("127.0.0.1", udp_port))
+
+            # Recv Legacy response (use executor to avoid blocking the event loop)
+            loop = asyncio.get_running_loop()
+            data, addr = await loop.run_in_executor(None, client_sock.recvfrom, 1024)
+            assert data.decode("utf-8") == "001122334455"
+            client_sock.close()
+
+            # 3. Test UDP Discovery (Upgraded mode)
+            # Listen on the response_udp_port we specified
+            resp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            resp_sock.settimeout(1.0)
+            resp_sock.bind(("127.0.0.1", resp_udp_port))
+
+            # Send discovery ping again
+            client_sock2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            client_sock2.sendto(b"RBD-ANDROID", ("127.0.0.1", udp_port))
+
+            # Legacy response will be sent to client_sock2 (which we ignore),
+            # but upgraded response should arrive on resp_sock
+            data_upgraded, addr_upgraded = await loop.run_in_executor(
+                None, resp_sock.recvfrom, 1024
+            )
+            assert data_upgraded.decode("utf-8") == "test-uuid-12345"
+            resp_sock.close()
+            client_sock2.close()
+
+            # 4. Test HTTP Stick JSON-RPC POST `/stick`
+            async with aiohttp.ClientSession() as session:
+                url = f"http://127.0.0.1:{http_port}/stick"
+
+                # Command: Model and Version (02)
+                payload = {
+                    "jsonrpc": "2.0",
+                    "method": "tunnelSip",
+                    "params": {"data": "02", "length": 1},
+                    "id": 1,
+                }
+                async with session.post(url, json=payload) as resp:
+                    assert resp.status == 200
+                    resp_bytes = await resp.read()
+                    resp_json = json.loads(resp_bytes.decode("utf-8"))
+                    assert resp_json["id"] == 1
+                    # 82 = response code (02 + 80), 0005 = model (ESP-TM2), 01 = major version, 03 = minor version
+                    assert resp_json["result"]["data"] == "8200050103"
+
+                # 5. Spin up a mock phone server to serve the firmware files
+                mock_phone_app = web.Application()
+
+                async def mock_release_json(request: web.Request) -> web.Response:
+                    return web.json_response({"version": "2.0"})
+
+                async def mock_filesystem_bin(request: web.Request) -> web.Response:
+                    return web.Response(
+                        body=b"fakebinarydata", content_type="application/octet-stream"
+                    )
+
+                mock_phone_app.router.add_get("/lnkfw/release.json", mock_release_json)
+                mock_phone_app.router.add_get(
+                    "/lnkfw/filesystem.bin", mock_filesystem_bin
+                )
+
+                phone_runner = web.AppRunner(mock_phone_app)
+                await phone_runner.setup()
+                phone_site = web.TCPSite(phone_runner, "127.0.0.1", 0)
+                await phone_site.start()
+                phone_port = phone_runner.addresses[0][1]
+
+                try:
+                    update_payload = {
+                        "jsonrpc": "2.0",
+                        "method": "requestFwUpdate",
+                        "params": {
+                            "lnk_update_url": f"http://127.0.0.1:{phone_port}/lnkfw/",
+                            "unv_update_url": "",
+                        },
+                        "id": 2,
+                    }
+                    async with session.post(url, json=update_payload) as resp:
+                        assert resp.status == 200
+                        resp_json = await resp.json()
+                        assert resp_json["result"]["status"] == "OK"
+
+                    # Wait for download background task to finish
+                    for _ in range(50):
+                        status_payload = {
+                            "jsonrpc": "2.0",
+                            "method": "getFwUpdateStatus",
+                            "id": 3,
+                        }
+                        async with session.post(
+                            url, json=status_payload
+                        ) as resp_status:
+                            assert resp_status.status == 200
+                            status_json = await resp_status.json()
+                            res = status_json["result"]
+                            if res["updateStatus"] == 0:  # OK
+                                break
+                        await asyncio.sleep(0.1)
+
+                    # Assert status is OK and progress completed
+                    assert res["updateStatus"] == 0
+                    assert res["lnkProgress"] == 100
+                finally:
+                    await phone_site.stop()
+                    await phone_runner.cleanup()
+
+        finally:
+            await server.stop()


### PR DESCRIPTION
This PR introduces two main enhancements on top of the merged cloud stream client changes:

1. **Local Discovery & Mock Simulator**:
   - Added UDP broadcast discovery capability to query local controllers.
   - Built a local controller fake device simulator and server (`pyrainbird.fake`) to emulate stick RPC endpoints (`tunnelSip`, `requestFwUpdate`, `getFwUpdateStatus`) for local integration and automated tests.

2. **Strongly-Typed Stream Events & Updatable States**:
   - Refactored `CloudStreamEvent` into a class hierarchy matching database sort keys (`StationStateEvent`, `RainSensorStateEvent`, `ConnectionStatusEvent`, `RssiStateEvent`, `GenericCloudStreamEvent`), isolating state and clock alignment parsing.
   - Added `update_zone(zone, active)` to the `States` model class to support stateless, caller-managed active zone updates.
   - Upgraded CLI `stream_cloud` command to check event subclass types and format output cleanly.