### PR TITLE
refactor: Decouple cloud REST client and OIDC token providers

### DIFF
--- a/examples/rainbird_tool.py
+++ b/examples/rainbird_tool.py
@@ -30,6 +30,7 @@ from pyrainbird.cloud import (
     ConnectionStatusEvent,
     GenericCloudStreamEvent,
     RainSensorStateEvent,
+    RainbirdCloudTokenProvider,
     RssiStateEvent,
     StationStateEvent,
     create_cloud_controller,
@@ -38,24 +39,30 @@ from pyrainbird.cloud import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def create_cloud_client(session: aiohttp.ClientSession) -> AsyncRainbirdCloudClient:
-    """Create AsyncRainbirdCloudClient from environment variables."""
+def create_cloud_token_provider(
+    session: aiohttp.ClientSession, config_file: str
+) -> CachingTokenProvider:
+    """Create a CachingTokenProvider wrapped around a RainbirdCloudTokenProvider."""
     username = os.environ.get("RAINBIRD_CLOUD_USERNAME") or os.environ.get(
         "RAINBIRD_USERNAME"
     )
     password = os.environ.get("RAINBIRD_CLOUD_PASSWORD") or os.environ.get(
         "RAINBIRD_PASSWORD"
     )
-    return AsyncRainbirdCloudClient(session, username=username, password=password)
+    if not username or not password:
+        raise ValueError(
+            "Username and password are required in environment variables "
+            "(RAINBIRD_CLOUD_USERNAME / RAINBIRD_CLOUD_PASSWORD)."
+        )
+    auth_provider = RainbirdCloudTokenProvider(session, username, password)
+    return CachingTokenProvider(config_file, auth_provider)
 
 
 async def discover_cloud(session: aiohttp.ClientSession, config_file: str) -> None:
     """Authenticate with the cloud and list registered satellites/controllers."""
-    client = create_cloud_client(session)
-    token_provider = CachingTokenProvider(client, config_file)
-    client.token_provider = token_provider
-
     try:
+        token_provider = create_cloud_token_provider(session, config_file)
+        client = AsyncRainbirdCloudClient(session, token_provider)
         satellites = await client.get_satellites()
         token = await token_provider.async_get_token()
         print(f"Authentication successful! Token: {token[:10]}...")
@@ -76,11 +83,9 @@ async def stream_cloud(
     session: aiohttp.ClientSession, config_file: str, satellite_id: int
 ) -> None:
     """Connect to the cloud real-time updates WebSocket stream."""
-    client = create_cloud_client(session)
-    token_provider = CachingTokenProvider(client, config_file)
-    client.token_provider = token_provider
-
     try:
+        token_provider = create_cloud_token_provider(session, config_file)
+        client = AsyncRainbirdCloudClient(session, token_provider)
         satellites = await client.get_satellites()
 
         # Find the device_uuid for the given satellite_id
@@ -373,12 +378,18 @@ async def main():
             password = os.environ.get("RAINBIRD_CLOUD_PASSWORD") or os.environ.get(
                 "RAINBIRD_PASSWORD"
             )
+            if not username or not password:
+                raise ValueError(
+                    "Username and password are required in environment variables "
+                    "(RAINBIRD_CLOUD_USERNAME / RAINBIRD_CLOUD_PASSWORD)."
+                )
 
-            client = AsyncRainbirdCloudClient(session, username, password)
-            token_provider = CachingTokenProvider(client, args.config_file)
-            client.token_provider = token_provider
+            auth_provider = RainbirdCloudTokenProvider(session, username, password)
+            token_provider = CachingTokenProvider(args.config_file, auth_provider)
 
-            controller = create_cloud_controller(session, token_provider, satellite_id)
+            controller = create_cloud_controller(
+                session, satellite_id, token_provider=token_provider
+            )
         else:
             host = os.environ["RAINBIRD_SERVER"]
             password = os.environ["RAINBIRD_PASSWORD"]

--- a/pyrainbird/cloud/client.py
+++ b/pyrainbird/cloud/client.py
@@ -1,6 +1,7 @@
 """Cloud client for rainbird IQ4 service."""
 
 import asyncio
+from collections.abc import Callable, Awaitable
 import datetime
 import json
 import logging
@@ -26,7 +27,6 @@ API_BASE = "https://iq4server.rainbird.com/coreapi/api"
 CLIENT_ID = "C5A6F324-3CD3-4B22-9F78-B4835BA55D25"
 REDIRECT_URI = "https://iq4.rainbird.com/auth.html"
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-
 
 WAF_RETRY_INITIAL_BACKOFF = 10.0
 WAF_RETRY_BACKOFF_INCREMENT = 10.0
@@ -68,57 +68,41 @@ def _parse_login_validation_error(html: str) -> str | None:
     return None
 
 
-class AsyncRainbirdCloudClient:
-    """Rainbird cloud API client handling OIDC authentication and REST endpoints."""
+class RainbirdCloudTokenProvider(RainbirdTokenProvider):
+    """Token provider wrapping OIDC credentials authentication."""
 
     def __init__(
         self,
         session: aiohttp.ClientSession,
-        username: str | None = None,
-        password: str | None = None,
+        username: str,
+        password: str,
+        *,
         token: str | None = None,
-        token_provider: RainbirdTokenProvider | None = None,
+        token_update_callback: Callable[[str], Awaitable[None]] | None = None,
     ) -> None:
-        """Initialize AsyncRainbirdCloudClient."""
+        """Initialize RainbirdCloudTokenProvider."""
         self._session = session
         self._username = username
         self._password = password
         self._token = token
-        self._token_provider = token_provider
-        self._headers = {
-            "Accept": "application/json",
-            "User-Agent": DEFAULT_USER_AGENT,
-        }
-        if token:
-            self._headers["Authorization"] = f"Bearer {token}"
+        self._token_update_callback = token_update_callback
 
     @property
     def token(self) -> str | None:
-        """Return the cached access token."""
+        """Return the active bearer token."""
         return self._token
 
-    @property
-    def token_provider(self) -> RainbirdTokenProvider | None:
-        """Return the token provider."""
-        return self._token_provider
-
-    @token_provider.setter
-    def token_provider(self, provider: RainbirdTokenProvider | None) -> None:
-        """Set the token provider."""
-        self._token_provider = provider
+    async def async_get_token(self, force_refresh: bool = False) -> str:
+        """Return a valid Bearer token, refreshing if necessary or forced."""
+        if force_refresh or not self._token:
+            token = await self.login()
+            self._token = token
+            if self._token_update_callback:
+                await self._token_update_callback(token)
+        return self._token
 
     async def login(self, max_retries: int = 3) -> str:
-        """Authenticate using the OIDC Implicit Grant flow against ASP.NET Core Identity.
-
-        This emulates a standard browser sign-in process required by Microsoft identity
-        backends when direct REST credentials endpoints are unavailable. It performs the
-        following steps:
-        1. Initiates the OIDC authorize flow request.
-        2. Retrieves the standard ASP.NET Antiforgery CSRF verification token
-           (`__RequestVerificationToken`) from the HTML login form response.
-        3. Form-posts the username, password, return URL, and verification token.
-        4. Intercepts the final redirection fragment containing the JWT access token.
-        """
+        """Authenticate using the OIDC Implicit Grant flow against ASP.NET Core Identity."""
         if not self._username or not self._password:
             raise RainbirdAuthException("Username and password are required to log in.")
 
@@ -181,8 +165,7 @@ class AsyncRainbirdCloudClient:
                     raise
 
         self._token = access_token_value
-        self._headers["Authorization"] = f"Bearer {self._token}"
-        return self._token
+        return access_token_value
 
     async def _get_csrf_token(self, return_url: str, headers: dict[str, str]) -> str:
         """Fetch the login page and extract the CSRF token."""
@@ -318,20 +301,97 @@ class AsyncRainbirdCloudClient:
             "Could not retrieve access token from redirect chain."
         )
 
-    async def _async_get_token(self, force_refresh: bool = False) -> str:
-        """Resolve the active bearer token, either via provider or stored token."""
-        provider = self._token_provider or RainbirdCloudTokenProvider(self)
-        token = await provider.async_get_token(force_refresh=force_refresh)
+
+class CachingTokenProvider(RainbirdTokenProvider):
+    """Token provider that persists the Bearer token in a JSON file cache."""
+
+    def __init__(
+        self,
+        config_path: str,
+        auth_provider: RainbirdTokenProvider,
+    ) -> None:
+        """Initialize CachingTokenProvider."""
+        self._config_path = config_path
+        self._auth_provider = auth_provider
+        self._token: str | None = None
+
+    @property
+    def token(self) -> str | None:
+        """Return the active cached token."""
+        return self._token
+
+    def _save_token_to_cache(self, token: str) -> None:
+        """Save the token to the JSON config file."""
+        try:
+            os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
+            with open(self._config_path, "w", encoding="utf-8") as f:
+                json.dump({"token": token}, f, indent=2)
+            os.chmod(self._config_path, 0o600)
+        except Exception as err:
+            _LOGGER.warning("Failed to save token to cache: %s", err)
+
+    async def async_get_token(self, force_refresh: bool = False) -> str:
+        """Return a valid token, reading from environment, cache file, or auth provider."""
+        env_token = os.environ.get("RAINBIRD_CLOUD_TOKEN")
+        if env_token:
+            return env_token
+
+        if not force_refresh and self._token:
+            return self._token
+
+        if not force_refresh and os.path.exists(self._config_path):
+            try:
+                with open(self._config_path, "r", encoding="utf-8") as f:
+                    config = json.load(f)
+                    token = config.get("token")
+                if token:
+                    self._token = token
+                    return token
+            except Exception as err:
+                _LOGGER.warning("Failed to read token from cache: %s", err)
+
+        token = await self._auth_provider.async_get_token(force_refresh=force_refresh)
         self._token = token
-        self._headers["Authorization"] = f"Bearer {token}"
+        self._save_token_to_cache(token)
         return token
+
+
+class AsyncRainbirdCloudClient:
+    """Rainbird cloud API client handling REST endpoints."""
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        token_provider: RainbirdTokenProvider,
+    ) -> None:
+        """Initialize AsyncRainbirdCloudClient."""
+        self._session = session
+        self._token_provider = token_provider
+        self._headers = {
+            "Accept": "application/json",
+            "User-Agent": DEFAULT_USER_AGENT,
+        }
+
+    @property
+    def token_provider(self) -> RainbirdTokenProvider:
+        """Return the token provider."""
+        return self._token_provider
+
+    @token_provider.setter
+    def token_provider(self, provider: RainbirdTokenProvider) -> None:
+        """Set the token provider."""
+        self._token_provider = provider
 
     async def request(self, method: str, path: str, **kwargs: Any) -> Any:
         """Perform a REST API request with automatic 401 token refresh retries."""
         url = f"{API_BASE}/{path}"
-        await self._async_get_token()
+        token = await self._token_provider.async_get_token()
 
-        headers = {**self._headers, **kwargs.pop("headers", {})}
+        headers = {
+            **self._headers,
+            "Authorization": f"Bearer {token}",
+            **kwargs.pop("headers", {}),
+        }
 
         try:
             async with self._session.request(
@@ -343,8 +403,10 @@ class AsyncRainbirdCloudClient:
                         method,
                         path,
                     )
-                    await self._async_get_token(force_refresh=True)
-                    headers["Authorization"] = f"Bearer {self._token}"
+                    token = await self._token_provider.async_get_token(
+                        force_refresh=True
+                    )
+                    headers["Authorization"] = f"Bearer {token}"
                     async with self._session.request(
                         method, url, headers=headers, **kwargs
                     ) as retry_resp:
@@ -466,88 +528,15 @@ class AsyncRainbirdCloudClient:
         return data
 
 
-class RainbirdCloudTokenProvider(RainbirdTokenProvider):
-    """Token provider wrapping AsyncRainbirdCloudClient to manage Bearer tokens."""
-
-    def __init__(self, client: AsyncRainbirdCloudClient) -> None:
-        """Initialize RainbirdCloudTokenProvider."""
-        self._client = client
-
-    async def async_get_token(self, force_refresh: bool = False) -> str:
-        """Return a valid Bearer token, refreshing if necessary or forced."""
-        if force_refresh or not self._client.token:
-            await self._client.login()
-        token = self._client.token
-        if not token:
-            raise RainbirdAuthException("Could not retrieve a valid Bearer token.")
-        return token
-
-
-class CachingTokenProvider(RainbirdTokenProvider):
-    """Token provider that persists the Bearer token in a JSON file."""
-
-    def __init__(
-        self,
-        client: AsyncRainbirdCloudClient,
-        config_path: str,
-    ) -> None:
-        """Initialize CachingTokenProvider."""
-        self._client = client
-        self._config_path = config_path
-        self._client.token_provider = self
-
-    def _save_token_to_cache(self, token: str) -> None:
-        """Save the token to the JSON config file."""
-        try:
-            os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
-            with open(self._config_path, "w", encoding="utf-8") as f:
-                json.dump({"token": token}, f, indent=2)
-            os.chmod(self._config_path, 0o600)
-        except Exception as err:
-            _LOGGER.warning("Failed to save token to cache: %s", err)
-
-    async def async_get_token(self, force_refresh: bool = False) -> str:
-        """Return a valid token, reading from environment, cache file, or credentials login."""
-        env_token = os.environ.get("RAINBIRD_CLOUD_TOKEN")
-        if env_token:
-            self._client._token = env_token
-            self._client._headers["Authorization"] = f"Bearer {env_token}"
-            return env_token
-
-        if not force_refresh and self._client.token:
-            return self._client.token
-
-        if not force_refresh and os.path.exists(self._config_path):
-            try:
-                with open(self._config_path, "r", encoding="utf-8") as f:
-                    config = json.load(f)
-                    token = config.get("token")
-                if token:
-                    self._client._token = token
-                    self._client._headers["Authorization"] = f"Bearer {token}"
-                    return token
-            except Exception as err:
-                _LOGGER.warning("Failed to read token from cache: %s", err)
-
-        if not self._client._username or not self._client._password:
-            raise RainbirdAuthException(
-                "No cached token found and credentials (RAINBIRD_CLOUD_USERNAME/RAINBIRD_CLOUD_PASSWORD) are not set."
-            )
-
-        _LOGGER.info("Logging in to obtain a new token...")
-        token = await self._client.login()
-        self._save_token_to_cache(token)
-        return token
-
-
 async def async_authenticate_cloud(
     session: aiohttp.ClientSession,
     username: str,
     password: str,
 ) -> tuple[str, list[CloudSatellite]]:
     """Helper function to authenticate and fetch satellites in one call."""
-    client = AsyncRainbirdCloudClient(session, username, password)
-    token = await client.login()
+    token_provider = RainbirdCloudTokenProvider(session, username, password)
+    client = AsyncRainbirdCloudClient(session, token_provider)
+    token = await token_provider.async_get_token()
     satellites = await client.get_satellites()
     return token, satellites
 
@@ -677,8 +666,9 @@ class AsyncRainbirdCloudController(RainbirdController):
 
 def create_cloud_controller(
     session: aiohttp.ClientSession,
-    token_provider: RainbirdTokenProvider,
     satellite_id: int,
+    *,
+    token_provider: RainbirdTokenProvider,
 ) -> AsyncRainbirdCloudController:
     """Create an AsyncRainbirdCloudController with the specified token provider."""
     client = AsyncRainbirdCloudClient(session, token_provider=token_provider)

--- a/tests/cloud/test_client.py
+++ b/tests/cloud/test_client.py
@@ -1,6 +1,8 @@
 """Unit tests for the Rainbird cloud client."""
 
 from collections.abc import Generator
+import json
+import os
 from typing import Any
 from unittest import mock
 
@@ -10,6 +12,7 @@ from aiohttp.test_utils import TestClient
 
 from pyrainbird.cloud.client import (
     AsyncRainbirdCloudClient,
+    CachingTokenProvider,
     RainbirdCloudTokenProvider,
     async_authenticate_cloud,
 )
@@ -135,19 +138,15 @@ async def test_login_success(
     client_session = await aiohttp_client(mock_cloud_app)
 
     mock_auth_base = "/coreidentityserver"
-    mock_api_base = "/coreapi/api"
 
-    with (
-        mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base),
-        mock.patch("pyrainbird.cloud.client.API_BASE", new=mock_api_base),
-    ):
-        client = AsyncRainbirdCloudClient(
+    with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-        token = await client.login()
+        token = await provider.login()
 
         assert token == "valid_access_token_abc123"
-        assert client.token == "valid_access_token_abc123"
+        assert provider.token == "valid_access_token_abc123"
         assert mock_cloud_app["login_attempts"] == 1
 
 
@@ -161,11 +160,11 @@ async def test_login_invalid_credentials(
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "wrong_password"
         )
         with pytest.raises(RainbirdAuthException, match="Invalid credentials"):
-            await client.login()
+            await provider.login()
 
 
 async def test_login_missing_csrf(
@@ -179,13 +178,13 @@ async def test_login_missing_csrf(
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdApiException, match="Could not find __RequestVerificationToken"
         ):
-            await client.login()
+            await provider.login()
 
 
 async def test_login_invalid_redirect_payload(
@@ -199,11 +198,14 @@ async def test_login_invalid_redirect_payload(
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-        with pytest.raises(RainbirdAuthException, match="could not find access_token"):
-            await client.login()
+        with pytest.raises(
+            RainbirdAuthException,
+            match="Reached redirect URI but could not find access_token",
+        ):
+            await provider.login()
 
 
 async def test_login_infinite_redirect(
@@ -217,13 +219,13 @@ async def test_login_infinite_redirect(
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException, match="Maximum redirect limit reached"
         ):
-            await client.login()
+            await provider.login()
 
 
 async def test_get_satellites_success(
@@ -240,11 +242,11 @@ async def test_get_satellites_success(
         mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base),
         mock.patch("pyrainbird.cloud.client.API_BASE", new=mock_api_base),
     ):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-        # Login first to get token
-        await client.login()
+        client = AsyncRainbirdCloudClient(client_session, provider)
+        await provider.login()
 
         satellites = await client.get_satellites()
         assert len(satellites) == 1
@@ -275,13 +277,13 @@ async def test_get_satellites_auto_refresh_on_401(
         mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base),
         mock.patch("pyrainbird.cloud.client.API_BASE", new=mock_api_base),
     ):
-        # Initialize client with credentials and an expired/invalid token
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session,
             "user@example.com",
             "correct_password",
             token="expired_token",
         )
+        client = AsyncRainbirdCloudClient(client_session, provider)
 
         mock_cloud_app["token_valid"] = False  # Initially unauthorized
 
@@ -307,10 +309,10 @@ async def test_get_satellites_raises_unauthorized_if_retry_fails(
         mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base),
         mock.patch("pyrainbird.cloud.client.API_BASE", new=mock_api_base),
     ):
-        # Initialize client with wrong password so refresh also fails
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "wrong_password", token="expired_token"
         )
+        client = AsyncRainbirdCloudClient(client_session, provider)
         mock_cloud_app["token_valid"] = False
 
         with pytest.raises(RainbirdAuthException, match="Invalid credentials"):
@@ -327,12 +329,11 @@ async def test_cloud_token_provider(
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-        provider = RainbirdCloudTokenProvider(client)
 
-        assert client.token is None
+        assert provider.token is None
         # 1. Fetching first time triggers login
         token1 = await provider.async_get_token()
         assert token1 == "valid_access_token_abc123"
@@ -380,20 +381,15 @@ async def test_caching_token_provider(
     tmp_path: Any,
 ) -> None:
     """Test CachingTokenProvider loading, saving, and overriding."""
-    import json
-    import os
-    from examples.rainbird_tool import CachingTokenProvider
-
     client_session = await aiohttp_client(mock_cloud_app)
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        auth_provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-
         config_file = tmp_path / "rainbird.json"
-        provider = CachingTokenProvider(client, str(config_file))
+        provider = CachingTokenProvider(str(config_file), auth_provider)
 
         # 1. No environment variable, no cache file: triggers login, saves to cache
         assert not config_file.exists()
@@ -413,7 +409,7 @@ async def test_caching_token_provider(
         assert mock_cloud_app["login_attempts"] == 1
 
         # 3. If in-memory is cleared but config file exists, retrieves from config file
-        client._token = None
+        provider._token = None
         token3 = await provider.async_get_token()
         assert token3 == "valid_access_token_abc123"
         assert mock_cloud_app["login_attempts"] == 1
@@ -437,11 +433,13 @@ async def test_caching_token_provider(
             assert token5 == "env_override_token"
 
         # 6. Missing config file and missing credentials raises RainbirdAuthException
-        client_no_creds = AsyncRainbirdCloudClient(client_session)
+        auth_no_creds = RainbirdCloudTokenProvider(client_session, "", "")
         provider_no_creds = CachingTokenProvider(
-            client_no_creds, str(tmp_path / "nonexistent.json")
+            str(tmp_path / "nonexistent.json"), auth_no_creds
         )
-        with pytest.raises(RainbirdAuthException, match="No cached token found"):
+        with pytest.raises(
+            RainbirdAuthException, match="Username and password are required to log in"
+        ):
             await provider_no_creds.async_get_token()
 
 
@@ -451,21 +449,17 @@ async def test_caching_token_provider_waf_retry(
     tmp_path: Any,
 ) -> None:
     """Test CachingTokenProvider retries when encountering WAF challenges (202)."""
-    import json
-    from examples.rainbird_tool import CachingTokenProvider
-
     client_session = await aiohttp_client(mock_cloud_app)
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        auth_provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-
         config_file = tmp_path / "rainbird.json"
-        provider = CachingTokenProvider(client, str(config_file))
+        provider = CachingTokenProvider(str(config_file), auth_provider)
 
-        original_get_csrf = client._get_csrf_token
+        original_get_csrf = auth_provider._get_csrf_token
         call_count = 0
 
         async def mock_get_csrf(*args: Any, **kwargs: Any) -> str:
@@ -480,10 +474,11 @@ async def test_caching_token_provider_waf_retry(
             return await original_get_csrf(*args, **kwargs)
 
         with (
-            mock.patch.object(client, "_get_csrf_token", side_effect=mock_get_csrf),
+            mock.patch.object(
+                auth_provider, "_get_csrf_token", side_effect=mock_get_csrf
+            ),
             mock.patch("asyncio.sleep", return_value=None) as mock_sleep,
         ):
-            # Test direct client.login call (which invokes on_token_update and writes to config)
             token = await provider.async_get_token()
             assert token == "valid_access_token_abc123"
             assert call_count == 2
@@ -501,18 +496,15 @@ async def test_caching_token_provider_waf_retry_limit_exceeded(
     tmp_path: Any,
 ) -> None:
     """Test CachingTokenProvider stops retrying and raises when WAF retry limit is exceeded."""
-    from examples.rainbird_tool import CachingTokenProvider
-
     client_session = await aiohttp_client(mock_cloud_app)
     mock_auth_base = "/coreidentityserver"
 
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        auth_provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-
         config_file = tmp_path / "rainbird.json"
-        provider = CachingTokenProvider(client, str(config_file))
+        provider = CachingTokenProvider(str(config_file), auth_provider)
 
         async def mock_get_csrf(*args: Any, **kwargs: Any) -> str:
             from pyrainbird.exceptions import RainbirdConnectionError
@@ -522,10 +514,11 @@ async def test_caching_token_provider_waf_retry_limit_exceeded(
             )
 
         with (
-            mock.patch.object(client, "_get_csrf_token", side_effect=mock_get_csrf),
+            mock.patch.object(
+                auth_provider, "_get_csrf_token", side_effect=mock_get_csrf
+            ),
             mock.patch("asyncio.sleep", return_value=None) as mock_sleep,
         ):
-            # Test that login raises after 3 retries (4 attempts total)
             with pytest.raises(
                 RainbirdAuthException,
                 match="AWS WAF challenge page detected. Login blocked by WAF",
@@ -536,11 +529,11 @@ async def test_caching_token_provider_waf_retry_limit_exceeded(
 
 async def test_login_missing_credentials(aiohttp_client: TestClient) -> None:
     """Test calling login without providing username and password raises RainbirdAuthException."""
-    client = AsyncRainbirdCloudClient(aiohttp_client, username=None, password=None)
+    provider = RainbirdCloudTokenProvider(aiohttp_client, "", "")
     with pytest.raises(
         RainbirdAuthException, match="Username and password are required to log in."
     ):
-        await client.login()
+        await provider.login()
 
 
 async def test_get_csrf_token_non_200_error(aiohttp_client: TestClient) -> None:
@@ -555,19 +548,19 @@ async def test_get_csrf_token_non_200_error(aiohttp_client: TestClient) -> None:
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdApiException, match="Failed to fetch login page, HTTP status: 500"
         ):
-            await client._get_csrf_token("http://return.url", {})
+            await provider._get_csrf_token("http://return.url", {})
 
 
 async def test_get_csrf_token_connection_error(aiohttp_client: TestClient) -> None:
     """Test _get_csrf_token when requesting CSRF token triggers a connection error."""
     client_session = await aiohttp_client(aiohttp.web.Application())
-    client = AsyncRainbirdCloudClient(
+    provider = RainbirdCloudTokenProvider(
         client_session, "user@example.com", "correct_password"
     )
     with mock.patch.object(
@@ -577,7 +570,7 @@ async def test_get_csrf_token_connection_error(aiohttp_client: TestClient) -> No
             RainbirdApiException,
             match="Connection error fetching login page: connection refused",
         ):
-            await client._get_csrf_token("http://return.url", {})
+            await provider._get_csrf_token("http://return.url", {})
 
 
 def test_parse_login_validation_error_captcha_challenge() -> None:
@@ -650,13 +643,15 @@ async def test_submit_credentials_waf_captcha_error(aiohttp_client: TestClient) 
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdApiException, match="AWS WAF challenge or captcha page detected"
         ):
-            await client._submit_credentials("http://return.url", "csrf_token_abc", {})
+            await provider._submit_credentials(
+                "http://return.url", "csrf_token_abc", {}
+            )
 
 
 async def test_submit_credentials_validation_error(aiohttp_client: TestClient) -> None:
@@ -675,14 +670,16 @@ async def test_submit_credentials_validation_error(aiohttp_client: TestClient) -
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException,
             match="Invalid credentials or authentication failure: Account is locked",
         ):
-            await client._submit_credentials("http://return.url", "csrf_token_abc", {})
+            await provider._submit_credentials(
+                "http://return.url", "csrf_token_abc", {}
+            )
 
 
 async def test_submit_credentials_unknown_validation_error(
@@ -703,14 +700,16 @@ async def test_submit_credentials_unknown_validation_error(
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException,
             match="Invalid credentials or authentication failure.",
         ):
-            await client._submit_credentials("http://return.url", "csrf_token_abc", {})
+            await provider._submit_credentials(
+                "http://return.url", "csrf_token_abc", {}
+            )
 
 
 async def test_submit_credentials_non_redirect_error(
@@ -727,14 +726,16 @@ async def test_submit_credentials_non_redirect_error(
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException,
             match="Unexpected response status submitting credentials: 500",
         ):
-            await client._submit_credentials("http://return.url", "csrf_token_abc", {})
+            await provider._submit_credentials(
+                "http://return.url", "csrf_token_abc", {}
+            )
 
 
 async def test_submit_credentials_missing_location_header_error(
@@ -751,20 +752,22 @@ async def test_submit_credentials_missing_location_header_error(
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException,
             match="No redirect location returned after credentials submission.",
         ):
-            await client._submit_credentials("http://return.url", "csrf_token_abc", {})
+            await provider._submit_credentials(
+                "http://return.url", "csrf_token_abc", {}
+            )
 
 
 async def test_submit_credentials_connection_error(aiohttp_client: TestClient) -> None:
     """Test credentials submission triggering a connection exception raises RainbirdApiException."""
     client_session = await aiohttp_client(aiohttp.web.Application())
-    client = AsyncRainbirdCloudClient(
+    provider = RainbirdCloudTokenProvider(
         client_session, "user@example.com", "correct_password"
     )
     with mock.patch.object(
@@ -774,7 +777,9 @@ async def test_submit_credentials_connection_error(aiohttp_client: TestClient) -
             RainbirdApiException,
             match="Connection error submitting credentials: network failure",
         ):
-            await client._submit_credentials("http://return.url", "csrf_token_abc", {})
+            await provider._submit_credentials(
+                "http://return.url", "csrf_token_abc", {}
+            )
 
 
 async def test_follow_redirects_max_limit_error(aiohttp_client: TestClient) -> None:
@@ -789,13 +794,13 @@ async def test_follow_redirects_max_limit_error(aiohttp_client: TestClient) -> N
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException, match="Maximum redirect limit reached during login."
         ):
-            await client._follow_redirects("/step1", {})
+            await provider._follow_redirects("/step1", {})
 
 
 async def test_follow_redirects_absolute_url_success(
@@ -817,10 +822,10 @@ async def test_follow_redirects_absolute_url_success(
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-        token = await client._follow_redirects("/step1", {})
+        token = await provider._follow_redirects("/step1", {})
         assert token == "token123"
 
 
@@ -841,14 +846,14 @@ async def test_follow_redirects_missing_token_error(aiohttp_client: TestClient) 
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException,
             match="Reached redirect URI but could not find access_token in fragment.",
         ):
-            await client._follow_redirects("/step1", {})
+            await provider._follow_redirects("/step1", {})
 
 
 async def test_follow_redirects_premature_status_error(
@@ -865,20 +870,20 @@ async def test_follow_redirects_premature_status_error(
     client_session = await aiohttp_client(mock_app)
     mock_auth_base = ""
     with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
         with pytest.raises(
             RainbirdAuthException,
             match="Redirection stopped prematurely at status 200.",
         ):
-            await client._follow_redirects("/step1", {})
+            await provider._follow_redirects("/step1", {})
 
 
 async def test_follow_redirects_connection_error(aiohttp_client: TestClient) -> None:
     """Test redirect follow flow raises RainbirdApiException when network exceptions occur."""
     client_session = await aiohttp_client(aiohttp.web.Application())
-    client = AsyncRainbirdCloudClient(
+    provider = RainbirdCloudTokenProvider(
         client_session, "user@example.com", "correct_password"
     )
     with mock.patch.object(
@@ -888,7 +893,7 @@ async def test_follow_redirects_connection_error(aiohttp_client: TestClient) -> 
             RainbirdApiException,
             match="Connection error following login redirect: ssl protocol error",
         ):
-            await client._follow_redirects("/step1", {})
+            await provider._follow_redirects("/step1", {})
 
 
 async def test_get_satellites_dict_instead_of_list_error(
@@ -905,10 +910,11 @@ async def test_get_satellites_dict_instead_of_list_error(
         mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base),
         mock.patch("pyrainbird.cloud.client.API_BASE", new=mock_api_base),
     ):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-        await client.login()
+        client = AsyncRainbirdCloudClient(client_session, provider)
+        await provider.login()
         with pytest.raises(
             RainbirdApiException, match="Expected satellite list response to be a list."
         ):
@@ -931,29 +937,25 @@ async def test_get_satellites_parsing_error(
         mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base),
         mock.patch("pyrainbird.cloud.client.API_BASE", new=mock_api_base),
     ):
-        client = AsyncRainbirdCloudClient(
+        provider = RainbirdCloudTokenProvider(
             client_session, "user@example.com", "correct_password"
         )
-        await client.login()
+        client = AsyncRainbirdCloudClient(client_session, provider)
+        await provider.login()
         with pytest.raises(RainbirdApiException, match="Error parsing satellite data"):
             await client.get_satellites()
 
 
 async def test_token_provider_getter_setter(aiohttp_client: TestClient) -> None:
     """Test the token_provider getter and setter methods."""
-    client = AsyncRainbirdCloudClient(
+    provider1 = RainbirdCloudTokenProvider(
         aiohttp_client, "user@example.com", "correct_password"
     )
-    assert client.token_provider is None
+    client = AsyncRainbirdCloudClient(aiohttp_client, provider1)
+    assert client.token_provider is provider1
 
-    from pyrainbird.cloud.client import RainbirdCloudTokenProvider
-
-    provider = RainbirdCloudTokenProvider(client)
-    client.token_provider = provider
-    assert client.token_provider is provider
-
-    with pytest.raises(
-        RainbirdAuthException, match="Could not retrieve a valid Bearer token."
-    ):
-        with mock.patch.object(client, "login", return_value=None):
-            await provider.async_get_token()
+    provider2 = RainbirdCloudTokenProvider(
+        aiohttp_client, "user2@example.com", "correct_password"
+    )
+    client.token_provider = provider2
+    assert client.token_provider is provider2

--- a/tests/cloud/test_controller.py
+++ b/tests/cloud/test_controller.py
@@ -5,7 +5,6 @@ from aiohttp import web
 from pyrainbird.cloud import (
     create_cloud_controller,
     RainbirdCloudTokenProvider,
-    AsyncRainbirdCloudClient,
 )
 
 SATELLITE_ID = 12345
@@ -137,18 +136,15 @@ async def test_cloud_controller_operations(mock_cloud_api, monkeypatch) -> None:
             self._token = "mock-access-token"
         else:
             self._token = "mock-access-token-refreshed"
-        self._headers["Authorization"] = f"Bearer {self._token}"
         return self._token
 
-    monkeypatch.setattr(AsyncRainbirdCloudClient, "login", mock_login)
+    monkeypatch.setattr(RainbirdCloudTokenProvider, "login", mock_login)
 
-    cloud_client = AsyncRainbirdCloudClient(
+    token_provider = RainbirdCloudTokenProvider(
         client_app.session, "user@example.com", PASSWORD
     )
-    token_provider = RainbirdCloudTokenProvider(cloud_client)
-
     controller = create_cloud_controller(
-        client_app.session, token_provider, SATELLITE_ID
+        client_app.session, SATELLITE_ID, token_provider=token_provider
     )
 
     # 1. Verify basic properties


### PR DESCRIPTION
This PR refactors the Rain Bird cloud client into a clean, decoupled architecture.

### Changes
1. **Decoupled Client & Provider**:
   * `AsyncRainbirdCloudClient` is now focused purely on REST API request execution and takes `token_provider` in its constructor. It no longer accepts credentials (`username`, `password`) or manages login mechanics directly.
   * `RainbirdCloudTokenProvider` encapsulates OIDC Implicit Grant authentication mechanics, CSRF token extraction, credential submission, and redirection tracking.
   * `CachingTokenProvider` operates as a clean wrapper decorator using composition on `auth_provider: RainbirdTokenProvider` without referencing the client.
2. **Simplified Example & Controller Factories**:
   * Factory/helpers (`async_authenticate_cloud`, `create_cloud_controller`) are simplified to cleanly coordinate client/provider instances.
3. **Tests & Examples**:
   * Command-line examples in `examples/rainbird_tool.py` and unit tests in `tests/cloud/test_client.py` & `tests/cloud/test_controller.py` are updated to match the new constructor signatures.