### PR TITLE
feat: Add local connection pacing and unified backoff retry layer

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -23,11 +23,13 @@ a time and may raise exceptions when the device is busy. Keep this in mind when 
 and querying the device.
 """
 
+import asyncio
 import datetime
 import enum
 import logging
 import math
 import ssl
+import time
 from collections.abc import Callable
 from http import HTTPStatus
 from typing import Any, TypeVar, Union
@@ -173,13 +175,14 @@ HEAD = {
 }
 DATA = "data"
 CLOUD_API_URL = "http://rdz-rbcloud.rainbird.com/phone-api"
+LOCAL_MIN_DELAY = 0.1
 
 # In general, these devices can handle only one in flight request at a time
 # otherwise return a 503. The caller is expected to follow that, however ESP
 # ME devices also seem to return 503s more regularly than other devices so we
 # include retry behavior for them. We only retry the specific device busy error.
 START_TIMEOUT = 1.0
-ATTEMPTS = 3
+ATTEMPTS = 5
 
 
 def _retry_delay() -> float:
@@ -199,6 +202,36 @@ def _device_busy_retry() -> JitterRetry:
     )
 
 
+def _local_resiliency_retry(client: "AsyncRainbirdClient") -> JitterRetry:
+    exceptions = {
+        aiohttp.ClientError,
+        asyncio.TimeoutError,
+        TimeoutError,
+        RainbirdDeviceBusyException,
+        RainbirdConnectionError,
+    }
+
+    async def evaluate_response(response: aiohttp.ClientResponse) -> bool:
+        if response.status == HTTPStatus.SERVICE_UNAVAILABLE:
+            raise RainbirdDeviceBusyException("Rain Bird device is busy")
+        if response.status == HTTPStatus.FORBIDDEN:
+            raise RainbirdAuthException("Incorrect password")
+
+        response.raise_for_status()
+
+        content = await response.read()
+        client._coder.decode_command(content)
+        return True
+
+    return JitterRetry(
+        attempts=_retry_attempts(),
+        start_timeout=_retry_delay(),
+        exceptions=exceptions,
+        evaluate_response_callback=evaluate_response,
+        statuses=set(),
+    )
+
+
 class AsyncRainbirdClient:
     """An asyncio rainbird client.
 
@@ -212,6 +245,7 @@ class AsyncRainbirdClient:
         password: Union[str, None],
         *,
         ssl_context: ssl.SSLContext | bool | None = None,
+        min_delay: float = 0.0,
     ) -> None:
         self._websession = websession
         self._url = url
@@ -219,6 +253,8 @@ class AsyncRainbirdClient:
         _LOGGER.debug("Using Rain Bird API endpoint: %s", self._url)
         self._password = password
         self._coder = encryption.PayloadCoder(password, _LOGGER)
+        self._last_request_time = 0.0
+        self._min_delay = min_delay
 
     def with_retry_options(self, retry_options: RetryOptions) -> "AsyncRainbirdClient":  # type: ignore[valid-type]
         """Create a new AsyncRainbirdClient with retry options."""
@@ -227,27 +263,48 @@ class AsyncRainbirdClient:
             self._url,
             self._password,
             ssl_context=self._ssl_context,
+            min_delay=self._min_delay,
         )
 
     async def request(
         self, method: str, params: Union[dict[str, Any], None] = None
     ) -> dict[str, Any]:
         """Send a request for any command."""
+        # Enforce inter-request cooldown pacing if configured
+        if self._min_delay > 0.0:
+            now = time.time()
+            elapsed = now - self._last_request_time
+            if elapsed < self._min_delay:
+                sleep_time = self._min_delay - elapsed
+                _LOGGER.debug("Pacing requests: sleeping for %f seconds", sleep_time)
+                await asyncio.sleep(sleep_time)
+
         payload = self._coder.encode_command(method, params or {})
         try:
-            request_kwargs: dict[str, Any] = {}
-            if self._ssl_context is not None:
-                request_kwargs["ssl"] = self._ssl_context
-            resp = await self._websession.request(
-                "post", self._url, data=payload, headers=HEAD, **request_kwargs
-            )
-            resp.raise_for_status()
+            try:
+                request_kwargs: dict[str, Any] = {}
+                if self._ssl_context is not None:
+                    request_kwargs["ssl"] = self._ssl_context
+                if self._min_delay > 0.0:
+                    request_kwargs["timeout"] = aiohttp.ClientTimeout(total=10.0)
+                resp = await self._websession.request(
+                    "post", self._url, data=payload, headers=HEAD, **request_kwargs
+                )
+                resp.raise_for_status()
+            finally:
+                if self._min_delay > 0.0:
+                    self._last_request_time = time.time()
         except ClientConnectorCertificateError as err:
             _LOGGER.debug("Certificate verification failed: %s", err)
             raise RainbirdCertificateError(
                 "TLS certificate verification error communicating with Rain Bird device"
             ) from err
-        except (ClientConnectorError, ClientConnectorSSLError) as err:
+        except (
+            ClientConnectorError,
+            ClientConnectorSSLError,
+            asyncio.TimeoutError,
+            TimeoutError,
+        ) as err:
             _LOGGER.debug(
                 "Connection error communicating with Rain Bird device: %s", err
             )
@@ -264,7 +321,7 @@ class AsyncRainbirdClient:
                 raise RainbirdAuthException(
                     "Rain Bird device denied authentication; Incorrect Password?"
                 ) from err
-            raise RainbirdApiException("Rain Bird responded with an error")
+            raise RainbirdApiException("Rain Bird responded with an error") from err
         except ClientError as err:
             _LOGGER.debug("Error communicating with Rain Bird device: %s", err)
             raise RainbirdApiException(
@@ -279,7 +336,9 @@ def CreateController(
 ) -> "AsyncRainbirdController":
     """Create an AsyncRainbirdController."""
     local_url = f"http://{host}/stick"
-    local_client = AsyncRainbirdClient(websession, local_url, password)
+    local_client = AsyncRainbirdClient(
+        websession, local_url, password, min_delay=LOCAL_MIN_DELAY
+    )
     cloud_client = AsyncRainbirdClient(websession, CLOUD_API_URL, None)
     return AsyncRainbirdController(local_client, cloud_client)
 
@@ -312,6 +371,7 @@ async def create_controller(
             url,
             password,
             ssl_context=ssl_context,
+            min_delay=LOCAL_MIN_DELAY,
         )
         controller = AsyncRainbirdController(local_client, cloud_client)
         await controller.get_model_and_version()
@@ -352,10 +412,9 @@ class AsyncRainbirdController(RainbirdController):
         )
         if self._model is None:
             self._model = response
-            if self._model.model_info.retries:
-                self._local_client = self._local_client.with_retry_options(
-                    _device_busy_retry()
-                )
+            self._local_client = self._local_client.with_retry_options(
+                _local_resiliency_retry(self._local_client)
+            )
         return response
 
     async def get_available_stations(self) -> AvailableStations:

--- a/pyrainbird/encryption.py
+++ b/pyrainbird/encryption.py
@@ -11,7 +11,11 @@ from Crypto import Random
 from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
 
-from .exceptions import RainbirdApiException
+from .exceptions import (
+    RainbirdApiException,
+    RainbirdAuthException,
+    RainbirdDeviceBusyException,
+)
 
 
 BLOCK_SIZE = 16
@@ -28,6 +32,8 @@ class ErrorCode(enum.IntEnum):
     CHECKSUM_ERROR = 3
     UNKNOWN = 4
     METOD_NOT_SUPPORTED = -32601
+    LOCKOUT_ACTIVE = -32001
+    CONTROLLER_BUSY = -32002
 
 
 def _add_padding(data):
@@ -121,15 +127,25 @@ class PayloadCoder:
         response = json.loads(content)
         if error := response.get("error"):
             msg = ["Error from controller"]
-            if code := error.get("code"):
+            code = error.get("code")
+            message = error.get("message", "")
+            if code is not None:
                 try:
                     value = ErrorCode(code)
                 except ValueError:
                     value = ErrorCode.UNKNOWN
                 msg.append(f"Code: {str(value)}({code})")
-            if message := error.get("message"):
+            if message:
                 msg.append(f"Message: {message}")
             ", ".join(msg)
             self._logger.debug("Error from controller: %s", msg)
+            if code == ErrorCode.CONTROLLER_BUSY:
+                raise RainbirdDeviceBusyException(
+                    f"Rain Bird responded with an error: {message}"
+                )
+            if code == ErrorCode.LOCKOUT_ACTIVE:
+                raise RainbirdAuthException(
+                    f"Rain Bird responded with an error: {message}"
+                )
             raise RainbirdApiException(f"Rain Bird responded with an error: {message}")
         return response["result"]

--- a/tests/__snapshots__/test_async_client.ambr
+++ b/tests/__snapshots__/test_async_client.ambr
@@ -23,6 +23,10 @@
   }
   '''
 # ---
+# name: test_connection_timeout_retries_and_fails
+  list([
+  ])
+# ---
 # name: test_create_controller_does_not_fallback_on_auth_error
   list([
   ])
@@ -1396,7 +1400,7 @@
   }
   '''
 # ---
-# name: test_device_busy_retries_not_enabled
+# name: test_device_busy_retries_enabled_for_all_local_clients
   '''
   [client >]
   Intent: ModelAndVersionRequest (02)
@@ -1433,6 +1437,42 @@
   
   [error !]
   HTTP Status 503: Response had an error code
+  
+  [client >]
+  Intent: AvailableStationsRequest (0300)
+  Payload: {
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "tunnelSip",
+    "params": {
+      "data": "0300",
+      "length": 2
+    }
+  }
+  
+  [error !]
+  HTTP Status 503: Response had an error code
+  
+  [client >]
+  Intent: AvailableStationsRequest (0300)
+  Payload: {
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "tunnelSip",
+    "params": {
+      "data": "0300",
+      "length": 2
+    }
+  }
+  
+  [server <]
+  Payload: {
+    "jsonrpc": "2.0",
+    "result": {
+      "data": "83007F000000"
+    },
+    "id": 2
+  }
   '''
 # ---
 # name: test_error_response
@@ -8137,9 +8177,101 @@
   }
   '''
 # ---
+# name: test_jsonrpc_busy_retries_and_succeeds
+  '''
+  [client >]
+  Intent: ModelAndVersionRequest (02)
+  Payload: {
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "tunnelSip",
+    "params": {
+      "data": "02",
+      "length": 1
+    }
+  }
+  
+  [server <]
+  Payload: {
+    "jsonrpc": "2.0",
+    "result": {
+      "data": "82000A0103"
+    },
+    "id": 1
+  }
+  
+  [client >]
+  Intent: AvailableStationsRequest (0300)
+  Payload: {
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "tunnelSip",
+    "params": {
+      "data": "0300",
+      "length": 2
+    }
+  }
+  
+  [server <]
+  Payload: {
+    "jsonrpc": "2.0",
+    "error": {
+      "code": -32002,
+      "message": "Controller Busy"
+    },
+    "id": 1
+  }
+  
+  [client >]
+  Intent: AvailableStationsRequest (0300)
+  Payload: {
+    "id": 2,
+    "jsonrpc": "2.0",
+    "method": "tunnelSip",
+    "params": {
+      "data": "0300",
+      "length": 2
+    }
+  }
+  
+  [server <]
+  Payload: {
+    "jsonrpc": "2.0",
+    "result": {
+      "data": "83007F000000"
+    },
+    "id": 2
+  }
+  '''
+# ---
 # name: test_local_controller_capabilities
   list([
   ])
+# ---
+# name: test_lockout_error_aborts_immediately
+  '''
+  [client >]
+  Intent: ModelAndVersionRequest (02)
+  Payload: {
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "tunnelSip",
+    "params": {
+      "data": "02",
+      "length": 1
+    }
+  }
+  
+  [server <]
+  Payload: {
+    "jsonrpc": "2.0",
+    "error": {
+      "code": -32001,
+      "message": "Lockout Active"
+    },
+    "id": 1
+  }
+  '''
 # ---
 # name: test_non_retryable_errors
   '''

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import json
 from collections.abc import Awaitable, Callable, Generator
@@ -115,7 +116,13 @@ async def test_create_controller_tries_insecure_https_first() -> None:
 
     assert client_cls.call_args_list == [
         mock.call(session, mock.ANY, None),
-        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
+        mock.call(
+            session,
+            "https://example.com/stick",
+            "password",
+            ssl_context=False,
+            min_delay=0.1,
+        ),
     ]
 
 
@@ -138,8 +145,20 @@ async def test_create_controller_tries_https_then_http_on_connection_error() -> 
 
     assert client_cls.call_args_list == [
         mock.call(session, mock.ANY, None),
-        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
-        mock.call(session, "http://example.com/stick", "password", ssl_context=None),
+        mock.call(
+            session,
+            "https://example.com/stick",
+            "password",
+            ssl_context=False,
+            min_delay=0.1,
+        ),
+        mock.call(
+            session,
+            "http://example.com/stick",
+            "password",
+            ssl_context=None,
+            min_delay=0.1,
+        ),
     ]
 
 
@@ -158,7 +177,13 @@ async def test_create_controller_does_not_fallback_on_auth_error() -> None:
 
     assert client_cls.call_args_list == [
         mock.call(session, mock.ANY, None),
-        mock.call(session, "https://example.com/stick", "password", ssl_context=False),
+        mock.call(
+            session,
+            "https://example.com/stick",
+            "password",
+            ssl_context=False,
+            min_delay=0.1,
+        ),
     ]
 
 
@@ -296,7 +321,7 @@ async def test_non_retryable_errors(
         await controller.get_available_stations()
 
 
-async def test_device_busy_retries_not_enabled(
+async def test_device_busy_retries_enabled_for_all_local_clients(
     rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
     fake_device: FakeRainbirdDevice,
     rainbird_client: Callable[[], Awaitable[AsyncRainbirdClient]],
@@ -311,9 +336,74 @@ async def test_device_busy_retries_not_enabled(
     assert result.model_name == "ESP-TM2"
     assert not result.model_info.retries
 
+    # Make two attempts then succeed
     response(aiohttp.web.Response(status=503))
+    response(aiohttp.web.Response(status=503))
+    fake_device.stations = set(range(1, 8))
 
-    with pytest.raises(RainbirdDeviceBusyException):
+    stations = await controller.get_available_stations()
+    assert stations.active_set == {1, 2, 3, 4, 5, 6, 7}
+
+
+async def test_jsonrpc_busy_retries_and_succeeds(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    fake_device: FakeRainbirdDevice,
+    response: ResponseResult,
+) -> None:
+    """Test retrying on JSON-RPC -32002 busy response."""
+    controller = await rainbird_controller()
+    fake_device.set_model("ESP_TM2v2")
+    await controller.get_model_and_version()
+
+    # Queue a busy response first, then a success
+    busy_body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "error": {"code": -32002, "message": "Controller Busy"},
+            "id": 1,
+        }
+    )
+    encrypted_busy = encrypt(busy_body, PASSWORD)
+    response(aiohttp.web.Response(body=encrypted_busy))
+
+    fake_device.stations = set(range(1, 8))
+
+    stations = await controller.get_available_stations()
+    assert stations.active_set == {1, 2, 3, 4, 5, 6, 7}
+
+
+async def test_connection_timeout_retries_and_fails(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+) -> None:
+    """Test retrying on connection timeout error."""
+    controller = await rainbird_controller()
+    with (
+        mock.patch("aiohttp.ClientSession.request", side_effect=asyncio.TimeoutError),
+        mock.patch("pyrainbird.async_client._retry_attempts", return_value=3),
+        mock.patch("pyrainbird.async_client._retry_delay", return_value=0.01),
+    ):
+        with pytest.raises(RainbirdConnectionError):
+            await controller.get_available_stations()
+
+
+async def test_lockout_error_aborts_immediately(
+    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
+    response: ResponseResult,
+) -> None:
+    """Test that LOCKOUT_ACTIVE -32001 fails immediately without retrying."""
+    controller = await rainbird_controller()
+
+    lockout_body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "error": {"code": -32001, "message": "Lockout Active"},
+            "id": 1,
+        }
+    )
+    encrypted_lockout = encrypt(lockout_body, PASSWORD)
+    response(aiohttp.web.Response(body=encrypted_lockout))
+
+    with pytest.raises(RainbirdAuthException):
         await controller.get_available_stations()
 
 


### PR DESCRIPTION
### **Problem Context**
Upgraded Rain Bird LNK2 firmware modules (v4.x+) sync their state with the AWS IoT Core device shadow every 5 minutes. During this window, the module runs heavy TLS cryptography and locks the physical Manchester serial bus (`sip_manchester`). 

When local clients (like Home Assistant) attempt to query the local JSON-RPC API concurrently during this window, two issues occur:
1. The local request blocks on the hardware mutex, returning `-32002` (Controller Busy) or timing out.
2. Under concurrent network and bus load, the ESP32’s lwIP stack runs out of memory heap and triggers a watchdog reboot (causing a 1-minute dropout). If the client immediately reconnects, it accumulates sockets in `TIME_WAIT`, causing continuous boot-loops.

### **Proposed Solution**
This PR introduces a robust pacing and retry layer at the client level to gracefully handle local firmware locks and reboots:

1. **Constructor-Parameterized Pacing Delay (`min_delay=0.1`):** Enforces a minimum 100ms async cooldown between consecutive local JSON-RPC requests (`AsyncRainbirdClient`) to ensure the ESP32's lwIP stack has time to flush buffers and process serialized serial commands. Cloud client retains a default of `0.0`.
2. **Unified Backoff & Jitter Retry (`aiohttp_retry`):** Upgrades local clients to retry up to 5 times (using `JitterRetry` with exponential backoff) on connection errors, timeouts, status 503, and JSON-RPC `-32002` (Busy). 
3. **Explicit Error Code Exceptions:** Raises `RainbirdDeviceBusyException` on `-32002` (which triggers backoff retries) and `RainbirdAuthException` on `-32001` (lockout active, which aborts retries immediately to prevent brute-forcing CPU load).
4. **Local Request Timeout (10.0s):** Configures local requests with a 10-second timeout to prevent sockets from hanging indefinitely when the device is rebooting.

### **Verification**
* Verified via unit tests (`228 passed`).
* Verified against physical `ESP-TM2` controller (reproduced reboot loop, confirmed pacing log output, and watched `aiohttp_retry` silently recover on the 5th attempt after the reboot).
