### PR TITLE
fix: Resolve LNK2 firmware crash by fixing encryption padding

### DIFF
--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -202,36 +202,6 @@ def _device_busy_retry() -> JitterRetry:
     )
 
 
-def _local_resiliency_retry(client: "AsyncRainbirdClient") -> JitterRetry:
-    exceptions = {
-        aiohttp.ClientError,
-        asyncio.TimeoutError,
-        TimeoutError,
-        RainbirdDeviceBusyException,
-        RainbirdConnectionError,
-    }
-
-    async def evaluate_response(response: aiohttp.ClientResponse) -> bool:
-        if response.status == HTTPStatus.SERVICE_UNAVAILABLE:
-            raise RainbirdDeviceBusyException("Rain Bird device is busy")
-        if response.status == HTTPStatus.FORBIDDEN:
-            raise RainbirdAuthException("Incorrect password")
-
-        response.raise_for_status()
-
-        content = await response.read()
-        client._coder.decode_command(content)
-        return True
-
-    return JitterRetry(
-        attempts=_retry_attempts(),
-        start_timeout=_retry_delay(),
-        exceptions=exceptions,
-        evaluate_response_callback=evaluate_response,
-        statuses=set(),
-    )
-
-
 class AsyncRainbirdClient:
     """An asyncio rainbird client.
 
@@ -412,9 +382,10 @@ class AsyncRainbirdController(RainbirdController):
         )
         if self._model is None:
             self._model = response
-            self._local_client = self._local_client.with_retry_options(
-                _local_resiliency_retry(self._local_client)
-            )
+            if self._model.model_info.retries:
+                self._local_client = self._local_client.with_retry_options(
+                    _device_busy_retry()
+                )
         return response
 
     async def get_available_stations(self) -> AvailableStations:

--- a/pyrainbird/cloud/client.py
+++ b/pyrainbird/cloud/client.py
@@ -470,7 +470,7 @@ class AsyncRainbirdCloudClient:
                             )
                         if retry_resp.status == 204:
                             return None
-                        return await retry_resp.json()
+                        return await retry_resp.json(content_type=None)
 
                 if resp.status not in (200, 201, 204):
                     raise RainbirdApiException(
@@ -478,7 +478,7 @@ class AsyncRainbirdCloudClient:
                     )
                 if resp.status == 204:
                     return None
-                return await resp.json()
+                return await resp.json(content_type=None)
         except aiohttp.ClientError as err:
             raise RainbirdConnectionError(
                 f"Connection error requesting {path}: {err}"

--- a/pyrainbird/encryption.py
+++ b/pyrainbird/encryption.py
@@ -20,7 +20,7 @@ from .exceptions import (
 
 BLOCK_SIZE = 16
 INTERRUPT = "\x00"
-PAD = "\x10"
+PAD = "\x00"
 
 
 class ErrorCode(enum.IntEnum):
@@ -36,13 +36,9 @@ class ErrorCode(enum.IntEnum):
     CONTROLLER_BUSY = -32002
 
 
-def _add_padding(data):
-    new_data = data
-    new_data_len = len(new_data)
-    remaining_len = BLOCK_SIZE - new_data_len
-    to_pad_len = remaining_len % BLOCK_SIZE
-    pad_string = PAD * to_pad_len
-    return "".join([new_data, pad_string])
+def _add_padding(data: str) -> str:
+    pad_len = (BLOCK_SIZE - len(data) % BLOCK_SIZE) % BLOCK_SIZE
+    return data + (PAD * pad_len)
 
 
 def decrypt(encrypted_data, decrypt_key):
@@ -60,12 +56,11 @@ def decrypt(encrypted_data, decrypt_key):
 
 
 def encrypt(data, encryptkey):
-    tocodedata = data + "\x00\x10"
     m = SHA256.new()
     m.update(to_bytes(encryptkey))
     b = m.digest()
     iv = Random.new().read(16)
-    c = to_bytes(_add_padding(tocodedata))
+    c = to_bytes(_add_padding(data))
     m = SHA256.new()
     m.update(to_bytes(data))
     b2 = m.digest()

--- a/tests/__snapshots__/test_async_client.ambr
+++ b/tests/__snapshots__/test_async_client.ambr
@@ -23,10 +23,6 @@
   }
   '''
 # ---
-# name: test_connection_timeout_retries_and_fails
-  list([
-  ])
-# ---
 # name: test_create_controller_does_not_fallback_on_auth_error
   list([
   ])
@@ -1400,7 +1396,7 @@
   }
   '''
 # ---
-# name: test_device_busy_retries_enabled_for_all_local_clients
+# name: test_device_busy_retries_not_enabled
   '''
   [client >]
   Intent: ModelAndVersionRequest (02)
@@ -1437,42 +1433,6 @@
   
   [error !]
   HTTP Status 503: Response had an error code
-  
-  [client >]
-  Intent: AvailableStationsRequest (0300)
-  Payload: {
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "tunnelSip",
-    "params": {
-      "data": "0300",
-      "length": 2
-    }
-  }
-  
-  [error !]
-  HTTP Status 503: Response had an error code
-  
-  [client >]
-  Intent: AvailableStationsRequest (0300)
-  Payload: {
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "tunnelSip",
-    "params": {
-      "data": "0300",
-      "length": 2
-    }
-  }
-  
-  [server <]
-  Payload: {
-    "jsonrpc": "2.0",
-    "result": {
-      "data": "83007F000000"
-    },
-    "id": 2
-  }
   '''
 # ---
 # name: test_error_response
@@ -8177,101 +8137,9 @@
   }
   '''
 # ---
-# name: test_jsonrpc_busy_retries_and_succeeds
-  '''
-  [client >]
-  Intent: ModelAndVersionRequest (02)
-  Payload: {
-    "id": 1,
-    "jsonrpc": "2.0",
-    "method": "tunnelSip",
-    "params": {
-      "data": "02",
-      "length": 1
-    }
-  }
-  
-  [server <]
-  Payload: {
-    "jsonrpc": "2.0",
-    "result": {
-      "data": "82000A0103"
-    },
-    "id": 1
-  }
-  
-  [client >]
-  Intent: AvailableStationsRequest (0300)
-  Payload: {
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "tunnelSip",
-    "params": {
-      "data": "0300",
-      "length": 2
-    }
-  }
-  
-  [server <]
-  Payload: {
-    "jsonrpc": "2.0",
-    "error": {
-      "code": -32002,
-      "message": "Controller Busy"
-    },
-    "id": 1
-  }
-  
-  [client >]
-  Intent: AvailableStationsRequest (0300)
-  Payload: {
-    "id": 2,
-    "jsonrpc": "2.0",
-    "method": "tunnelSip",
-    "params": {
-      "data": "0300",
-      "length": 2
-    }
-  }
-  
-  [server <]
-  Payload: {
-    "jsonrpc": "2.0",
-    "result": {
-      "data": "83007F000000"
-    },
-    "id": 2
-  }
-  '''
-# ---
 # name: test_local_controller_capabilities
   list([
   ])
-# ---
-# name: test_lockout_error_aborts_immediately
-  '''
-  [client >]
-  Intent: ModelAndVersionRequest (02)
-  Payload: {
-    "id": 1,
-    "jsonrpc": "2.0",
-    "method": "tunnelSip",
-    "params": {
-      "data": "02",
-      "length": 1
-    }
-  }
-  
-  [server <]
-  Payload: {
-    "jsonrpc": "2.0",
-    "error": {
-      "code": -32001,
-      "message": "Lockout Active"
-    },
-    "id": 1
-  }
-  '''
 # ---
 # name: test_non_retryable_errors
   '''

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import datetime
 import json
 from collections.abc import Awaitable, Callable, Generator
@@ -321,7 +320,7 @@ async def test_non_retryable_errors(
         await controller.get_available_stations()
 
 
-async def test_device_busy_retries_enabled_for_all_local_clients(
+async def test_device_busy_retries_not_enabled(
     rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
     fake_device: FakeRainbirdDevice,
     rainbird_client: Callable[[], Awaitable[AsyncRainbirdClient]],
@@ -336,74 +335,9 @@ async def test_device_busy_retries_enabled_for_all_local_clients(
     assert result.model_name == "ESP-TM2"
     assert not result.model_info.retries
 
-    # Make two attempts then succeed
     response(aiohttp.web.Response(status=503))
-    response(aiohttp.web.Response(status=503))
-    fake_device.stations = set(range(1, 8))
 
-    stations = await controller.get_available_stations()
-    assert stations.active_set == {1, 2, 3, 4, 5, 6, 7}
-
-
-async def test_jsonrpc_busy_retries_and_succeeds(
-    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
-    fake_device: FakeRainbirdDevice,
-    response: ResponseResult,
-) -> None:
-    """Test retrying on JSON-RPC -32002 busy response."""
-    controller = await rainbird_controller()
-    fake_device.set_model("ESP_TM2v2")
-    await controller.get_model_and_version()
-
-    # Queue a busy response first, then a success
-    busy_body = json.dumps(
-        {
-            "jsonrpc": "2.0",
-            "error": {"code": -32002, "message": "Controller Busy"},
-            "id": 1,
-        }
-    )
-    encrypted_busy = encrypt(busy_body, PASSWORD)
-    response(aiohttp.web.Response(body=encrypted_busy))
-
-    fake_device.stations = set(range(1, 8))
-
-    stations = await controller.get_available_stations()
-    assert stations.active_set == {1, 2, 3, 4, 5, 6, 7}
-
-
-async def test_connection_timeout_retries_and_fails(
-    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
-) -> None:
-    """Test retrying on connection timeout error."""
-    controller = await rainbird_controller()
-    with (
-        mock.patch("aiohttp.ClientSession.request", side_effect=asyncio.TimeoutError),
-        mock.patch("pyrainbird.async_client._retry_attempts", return_value=3),
-        mock.patch("pyrainbird.async_client._retry_delay", return_value=0.01),
-    ):
-        with pytest.raises(RainbirdConnectionError):
-            await controller.get_available_stations()
-
-
-async def test_lockout_error_aborts_immediately(
-    rainbird_controller: Callable[[], Awaitable[AsyncRainbirdController]],
-    response: ResponseResult,
-) -> None:
-    """Test that LOCKOUT_ACTIVE -32001 fails immediately without retrying."""
-    controller = await rainbird_controller()
-
-    lockout_body = json.dumps(
-        {
-            "jsonrpc": "2.0",
-            "error": {"code": -32001, "message": "Lockout Active"},
-            "id": 1,
-        }
-    )
-    encrypted_lockout = encrypt(lockout_body, PASSWORD)
-    response(aiohttp.web.Response(body=encrypted_lockout))
-
-    with pytest.raises(RainbirdAuthException):
+    with pytest.raises(RainbirdDeviceBusyException):
         await controller.get_available_stations()
 
 


### PR DESCRIPTION
This PR fixes the padding behavior in the Rain Bird payload encryption to use pure null padding (\x00) directly up to the 16-byte boundary and removes the legacy \x00\x10 plaintext suffix. This prevents exceptions and reboots in the LNK2 C++ firmware. It also reverts the experimental local client retry resiliency behavior to restore original model-specific busy retry behavior.