### PR TITLE
feat: Disable pacing by default and allow passing custom min_delay

### DIFF
--- a/examples/rainbird_tool.py
+++ b/examples/rainbird_tool.py
@@ -334,7 +334,9 @@ async def main():
     args = parse_args()
     logging.basicConfig(level=getattr(logging, args.log_level.upper()))
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=1)
+    ) as session:
         if args.command == "discover_local":
             await discover_local(args.timeout)
             return

--- a/pyrainbird/async_client.py
+++ b/pyrainbird/async_client.py
@@ -302,19 +302,25 @@ class AsyncRainbirdClient:
 
 
 def CreateController(
-    websession: aiohttp.ClientSession, host: str, password: str
+    websession: aiohttp.ClientSession,
+    host: str,
+    password: str,
+    min_delay: float = 0.0,
 ) -> "AsyncRainbirdController":
     """Create an AsyncRainbirdController."""
     local_url = f"http://{host}/stick"
     local_client = AsyncRainbirdClient(
-        websession, local_url, password, min_delay=LOCAL_MIN_DELAY
+        websession, local_url, password, min_delay=min_delay
     )
     cloud_client = AsyncRainbirdClient(websession, CLOUD_API_URL, None)
     return AsyncRainbirdController(local_client, cloud_client)
 
 
 async def create_controller(
-    websession: aiohttp.ClientSession, host: str, password: str
+    websession: aiohttp.ClientSession,
+    host: str,
+    password: str,
+    min_delay: float = 0.0,
 ) -> "AsyncRainbirdController":
     """Create an AsyncRainbirdController with local HTTP/HTTPS discovery.
 
@@ -341,7 +347,7 @@ async def create_controller(
             url,
             password,
             ssl_context=ssl_context,
-            min_delay=LOCAL_MIN_DELAY,
+            min_delay=min_delay,
         )
         controller = AsyncRainbirdController(local_client, cloud_client)
         await controller.get_model_and_version()

--- a/pyrainbird/cloud/client.py
+++ b/pyrainbird/cloud/client.py
@@ -718,7 +718,7 @@ class AsyncRainbirdCloudController(RainbirdController):
 
         stations = await self._client.get_station_list(self._satellite_id)
         for station in stations:
-            station_num = station.station_number or station.number
+            station_num = station.station_number or station.number or station.terminal
             if station_num == zone:
                 self._station_id_map[zone] = station.id
                 return station.id
@@ -741,7 +741,7 @@ class AsyncRainbirdCloudController(RainbirdController):
         if not self._station_id_map:
             stations = await self._client.get_station_list(self._satellite_id)
             for s in stations:
-                num = s.station_number or s.number
+                num = s.station_number or s.number or s.terminal
                 if num is not None:
                     self._station_id_map[num] = s.id
 

--- a/tests/__snapshots__/test_async_client.ambr
+++ b/tests/__snapshots__/test_async_client.ambr
@@ -35,6 +35,10 @@
   list([
   ])
 # ---
+# name: test_create_controller_with_custom_min_delay
+  list([
+  ])
+# ---
 # name: test_custom_schedule
   '''
   [client >]

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -120,7 +120,7 @@ async def test_create_controller_tries_insecure_https_first() -> None:
             "https://example.com/stick",
             "password",
             ssl_context=False,
-            min_delay=0.1,
+            min_delay=0.0,
         ),
     ]
 
@@ -149,14 +149,14 @@ async def test_create_controller_tries_https_then_http_on_connection_error() -> 
             "https://example.com/stick",
             "password",
             ssl_context=False,
-            min_delay=0.1,
+            min_delay=0.0,
         ),
         mock.call(
             session,
             "http://example.com/stick",
             "password",
             ssl_context=None,
-            min_delay=0.1,
+            min_delay=0.0,
         ),
     ]
 
@@ -181,7 +181,31 @@ async def test_create_controller_does_not_fallback_on_auth_error() -> None:
             "https://example.com/stick",
             "password",
             ssl_context=False,
-            min_delay=0.1,
+            min_delay=0.0,
+        ),
+    ]
+
+
+async def test_create_controller_with_custom_min_delay() -> None:
+    session = mock.AsyncMock(spec=aiohttp.ClientSession)
+
+    with (
+        mock.patch("pyrainbird.async_client.AsyncRainbirdClient") as client_cls,
+        mock.patch(
+            "pyrainbird.async_client.AsyncRainbirdController.get_model_and_version",
+            new=mock.AsyncMock(return_value=ModelAndVersion(0x0A, 1, 3)),
+        ),
+    ):
+        await create_controller(session, "example.com", "password", min_delay=0.25)
+
+    assert client_cls.call_args_list == [
+        mock.call(session, mock.ANY, None),
+        mock.call(
+            session,
+            "https://example.com/stick",
+            "password",
+            ssl_context=False,
+            min_delay=0.25,
         ),
     ]
 


### PR DESCRIPTION
This PR disables local controller request pacing by default and parameterizes it so it can be passed via a controller argument.

### Changes
* Updated `CreateController` and `create_controller` signatures to accept `min_delay: float = 0.0`.
* Exposed local client pacing parameterization.
* Updated tests and snapshots.
* Includes fixes for station terminal mapping and CLI TCP socket connection cleanup.