### PR TITLE
feat: Run CachingTokenProvider file I/O operations in an executor

### DIFF
--- a/pyrainbird/cloud/client.py
+++ b/pyrainbird/cloud/client.py
@@ -370,8 +370,8 @@ class CachingTokenProvider(RainbirdTokenProvider):
         """Return the active cached token."""
         return self._token
 
-    def _save_token_to_cache(self, token: str) -> None:
-        """Save the token to the JSON config file."""
+    def _save_token_to_cache_sync(self, token: str) -> None:
+        """Save the token to the JSON config file synchronously."""
         try:
             os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
             with open(self._config_path, "w", encoding="utf-8") as f:
@@ -379,6 +379,23 @@ class CachingTokenProvider(RainbirdTokenProvider):
             os.chmod(self._config_path, 0o600)
         except OSError as err:
             _LOGGER.warning("Failed to save token to cache: %s", err)
+
+    async def _save_token_to_cache(self, token: str) -> None:
+        """Save the token to the JSON config file asynchronously."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._save_token_to_cache_sync, token)
+
+    def _load_token_from_cache_sync(self) -> str | None:
+        """Load the token from the JSON config file synchronously."""
+        if not os.path.exists(self._config_path):
+            return None
+        try:
+            with open(self._config_path, "r", encoding="utf-8") as f:
+                config = json.load(f)
+                return config.get("token")
+        except (OSError, json.JSONDecodeError) as err:
+            _LOGGER.warning("Failed to read token from cache: %s", err)
+            return None
 
     async def async_get_token(self, force_refresh: bool = False) -> str:
         """Return a valid token, reading from environment, cache file, or auth provider."""
@@ -389,20 +406,16 @@ class CachingTokenProvider(RainbirdTokenProvider):
         if not force_refresh and self._token:
             return self._token
 
-        if not force_refresh and os.path.exists(self._config_path):
-            try:
-                with open(self._config_path, "r", encoding="utf-8") as f:
-                    config = json.load(f)
-                    token = config.get("token")
-                if token:
-                    self._token = token
-                    return token
-            except (OSError, json.JSONDecodeError) as err:
-                _LOGGER.warning("Failed to read token from cache: %s", err)
+        if not force_refresh:
+            loop = asyncio.get_running_loop()
+            token = await loop.run_in_executor(None, self._load_token_from_cache_sync)
+            if token:
+                self._token = token
+                return token
 
         token = await self._auth_provider.async_get_token(force_refresh=force_refresh)
         self._token = token
-        self._save_token_to_cache(token)
+        await self._save_token_to_cache(token)
         return token
 
 

--- a/tests/cloud/test_client.py
+++ b/tests/cloud/test_client.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest import mock
 
 import aiohttp
+import asyncio
 import pytest
 from aiohttp.test_utils import TestClient
 
@@ -441,6 +442,43 @@ async def test_caching_token_provider(
             RainbirdAuthException, match="Username and password are required to log in"
         ):
             await provider_no_creds.async_get_token()
+
+
+async def test_caching_token_provider_non_blocking(
+    mock_cloud_app: aiohttp.web.Application,
+    aiohttp_client: TestClient,
+    tmp_path: Any,
+) -> None:
+    """Test that CachingTokenProvider offloads file I/O to an executor."""
+    client_session = await aiohttp_client(mock_cloud_app)
+    mock_auth_base = "/coreidentityserver"
+
+    with mock.patch("pyrainbird.cloud.client.AUTH_BASE", new=mock_auth_base):
+        auth_provider = RainbirdCloudTokenProvider(
+            client_session, "user@example.com", "correct_password"
+        )
+        config_file = tmp_path / "rainbird.json"
+        provider = CachingTokenProvider(str(config_file), auth_provider)
+
+        loop = asyncio.get_running_loop()
+        with mock.patch.object(
+            loop, "run_in_executor", wraps=loop.run_in_executor
+        ) as mock_run:
+            # First call loads via auth and saves to cache
+            token = await provider.async_get_token()
+            assert token == "valid_access_token_abc123"
+            # Assert _save_token_to_cache_sync was run in the executor
+            mock_run.assert_any_call(
+                None, provider._save_token_to_cache_sync, "valid_access_token_abc123"
+            )
+
+            # Clear token memory cache to force load from file
+            provider._token = None
+            mock_run.reset_mock()
+            token = await provider.async_get_token()
+            assert token == "valid_access_token_abc123"
+            # Assert _load_token_from_cache_sync was run in the executor
+            mock_run.assert_any_call(None, provider._load_token_from_cache_sync)
 
 
 async def test_caching_token_provider_waf_retry(


### PR DESCRIPTION
This PR refactors `CachingTokenProvider` to run all file I/O operations (such as configuration file existence checking, reading, directory creation, writing, and permissions updates) inside an executor thread, preventing blocking I/O in the asyncio event loop.

### Changes
* Moved file saving operations to `_save_token_to_cache_sync`.
* Moved file loading operations to `_load_token_from_cache_sync`.
* Scheduled both methods using `loop.run_in_executor(None, ...)`.
* Added `test_caching_token_provider_non_blocking` unit test to verify that the synchronous I/O helpers are run via `run_in_executor`.