### PR TITLE
chore(deps): remove unused responses dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,6 +19,5 @@ pytest-aiohttp==1.1.1
 pytest-asyncio==1.4.0
 pytest-golden==1.0.1
 python-dateutil==2.9.0.post0
-responses==0.26.2
 types-PyYAML==6.0.12.20260815
 syrupy>=5.1.0


### PR DESCRIPTION
The `responses` library was used for mocking synchronous requests, which was previously removed in favor of `aiohttp`. Removing this unused dependency from `requirements_dev.txt`.